### PR TITLE
Add David Small (local resolution weighting) mosaics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 * The `asf_tools` python package for working with Synthetic Aperture Radar (SAR) data. 
   See the [README](asf_tools/README.md)
+* `asf_tools.composite` and an associated `make_composite.py` entrypoint for making
+  mosaics using local resolution weighting (à la [David Smalls, 2012](https://doi.org/10.1109/IGARSS.2012.6350465))
 
 ### Changed
 * This repository moved from `ASFHyP3/GIS-tools` to [`ASFHyP3/asf-tools`](https://github.com/ASFHyP3/asf-tools) 

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 """Create S1 SAR Composite Mosaic using inverse area weighting ala David Small.
 
    Path vs infiles:
@@ -282,7 +281,7 @@ def make_composite(outfile, infiles=None, path=None, pol=None, resolution=None):
     logging.info("Program successfully completed")
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(prog="make_composite.py",
                                      description="Create a weighted composite mosaic from a set of S-1 RTC products",
                                      epilog='''Output pixel values calculated using weights that are the inverse of 

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -5,7 +5,7 @@
      If path is passed, code assumes files are in an ASF HyP3 RTC Stacking arrangement.
      i.e  {path}/20*/PRODUCT/ contains the input RTC data and the area maps or
           {path}/S1?_IW_*RTC*/ contains the input RTC data and the area maps
-         
+
 
 """
 
@@ -15,9 +15,7 @@ import os
 import re
 import argparse
 import glob
-# from hyp3lib import saa_func_lib as saa
-# import hyp3lib.saa_func_lib as saa
-import saa_func_lib as saa
+from hyp3lib import saa_func_lib as saa
 from osgeo import gdal
 from osgeo.gdalconst import GRIORA_Cubic
 
@@ -33,7 +31,7 @@ def get_pol(infile):
     elif "HV" in infile:
         pol = "HV"
     else:
-        raise Exception("Could not determine polarization of file " + infile)  
+        raise Exception("Could not determine polarization of file " + infile)
     return pol
 
 
@@ -56,7 +54,7 @@ def frange(start, stop=None, step=None):
 def get_full_extent(corners):
     """"Calculate the union of corners"""
     min_ulx = 50000000
-    max_lrx = 0 
+    max_lrx = 0
     max_uly = 0
     min_lry = 50000000
 
@@ -121,7 +119,7 @@ def reproject_to_median_utm(files, pol, resolution=None):
        Use either the given resolution or the largest resolution in the stack"""
 
     if len(files) < 2:
-        return None 
+        return None
 
     # Set the pixel size
     if resolution:
@@ -212,7 +210,7 @@ def make_composite(outfile, infiles=None, path=None, pol=None, resolution=None):
     # Get pixel size
     x, y, trans, proj = saa.read_gdal_file_geo(saa.open_gdal_file(resampled_files[0]))
     pixel_size_x = trans[1]
-    pixel_size_y = trans[5] 
+    pixel_size_y = trans[5]
     logging.info(f"{resampled_files[0]} x = {pixel_size_x} y = {pixel_size_y}")
 
     # Get extent of union of all images
@@ -223,7 +221,7 @@ def make_composite(outfile, infiles=None, path=None, pol=None, resolution=None):
     ulx, lrx, uly, lry = get_full_extent(extents)
 
     logging.info(f"Full extent of mosaic is {ulx,uly} to {lrx,lry}")
-   
+
     x_pixels = abs(int((ulx - lrx) / pixel_size_x))
     y_pixels = abs(int((lry - uly) / pixel_size_y))
 
@@ -254,17 +252,17 @@ def make_composite(outfile, infiles=None, path=None, pol=None, resolution=None):
             logging.info(f"Placing values in output grid at {int(out_loc_x)}:{int(end_loc_x)} "
                          f"and {int(out_loc_y)}:{int(end_loc_y)}")
 
-            temp = 1.0/areas 
+            temp = 1.0/areas
             temp[values == 0] = 0
             mask = np.ones((y_size,x_size),dtype = np.uint8)
             mask[values == 0] = 0
 
             outputs[int(out_loc_y):int(end_loc_y), int(out_loc_x):int(end_loc_x)] += values * temp
             weights[int(out_loc_y):int(end_loc_y), int(out_loc_x):int(end_loc_x)] += temp
-            counts[int(out_loc_y):int(end_loc_y), int(out_loc_x):int(end_loc_x)] += mask 
-             
-    # Divide by the total weight applied 
-    outputs /= weights 
+            counts[int(out_loc_y):int(end_loc_y), int(out_loc_x):int(end_loc_x)] += mask
+
+    # Divide by the total weight applied
+    outputs /= weights
 
     # write out composite
     logging.info("Writing output files")

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -18,6 +18,9 @@ dependencies:
   - pytest-console-scripts
   - pytest-cov
   # For running
+  - hyp3lib=1.6.2
+  - numpy
+  - gdal
   - pip:
     # for packaging and testing
     - s3pypi

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
 
     entry_points={
         'console_scripts': [
-            'asf_tools = asf_tools.__main__:main',
+            'make_composite.py = asf_tools.composite:main',
         ]
     },
 

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,11 @@ setup(
 
     python_requires='~=3.8',
 
-    # install_requires=[
-    #     'hyp3lib',
-    # ],
+    install_requires=[
+        'hyp3lib==1.6.2',
+        'numpy',
+        'gdal',
+    ],
 
     extras_require={
         'develop': [
@@ -48,10 +50,11 @@ setup(
 
     packages=find_packages(),
 
-    # entry_points={'console_scripts': [
-    #         'asf_tools = asf_tools.__main__:main',
-    #     ]
-    # },
+    entry_points={
+        'console_scripts': [
+            'asf_tools = asf_tools.__main__:main',
+        ]
+    },
 
     zip_safe=False,
 )

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,0 +1,3 @@
+def test_asf_tools(script_runner):
+    ret = script_runner.run('make_composite.py', '-h')
+    assert ret.success


### PR DESCRIPTION
This bring in the David Small mosaic code from hyp3-stacking into `asf_tools`. 

`src/make_composite.py` has been renamed to `asf_tools/composite.py`, and all previous history was included.

The hyp3-stacking history was filtered and rewritten using [git-filter-repo](https://github.com/newren/git-filter-repo) by running these commands:

```sh
git clone git@github.com:asfadmin/hyp3-stacking.git
cd hyp3-stacking

git filter-repo \
    --path src/make_composite.py \
    --path-rename 'src/make_composite.py':'asf_tools/composite.py'

git remote add asf-tools git@github.com:ASFHyP3/asf-tools.git
git push -u asf-tools test:add-composite

cd ..  # back to asf-tools
git fetch --all
git merge --no-ff --allow-unrelated-histories origin/add-composite
```