### PR TITLE
Simplify EPSG find and always handle antimerridian

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -44,11 +44,11 @@ def get_target_epsg_code(codes: List[int]) -> int:
     if not all([c in valid_codes for c in codes]):
         raise ValueError(f'Non UTM EPSG code encountered: {codes}')
 
-    hemispheres = [int(c // 100 * 100) for c in codes]
+    hemispheres = [c // 100 * 100 for c in codes]
     # if even modes, choose lowest (North)
     target_hemisphere = min(multimode(hemispheres))
 
-    zones = [int(c % 100) for c in codes]
+    zones = [c % 100 for c in codes]
     # if even modes, choose lowest
     target_zone = min(multimode(zones))
     return target_hemisphere + target_zone

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -51,6 +51,7 @@ def get_target_epsg_code(codes: List[int]) -> int:
     zones = [c % 100 for c in codes]
     # if even modes, choose lowest
     target_zone = min(multimode(zones))
+
     return target_hemisphere + target_zone
 
 

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -50,7 +50,7 @@ def get_target_epsg_code(codes: List[int]) -> int:
 
     zones = sorted([c % 100 for c in codes])
     # if even length, choose fist of median two
-    target_zone = zones[len(zones) // 2]
+    target_zone = zones[(len(zones) - 1) // 2]
 
     return target_hemisphere + target_zone
 

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -41,8 +41,8 @@ def get_target_epsg_code(codes: List[int]) -> int:
     #   North: 326XX
     #   South: 327XX
     valid_codes = list(range(32601, 32661)) + list(range(32701, 32761))
-    if not all([c in valid_codes for c in codes]):
-        raise ValueError(f'Non UTM EPSG code encountered: {codes}')
+    if bad_codes := set(codes) - set(valid_codes):
+        raise ValueError(f'Non UTM EPSG code encountered: {bad_codes}')
 
     hemispheres = [c // 100 * 100 for c in codes]
     # if even modes, choose lowest (North)

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -48,9 +48,9 @@ def get_target_epsg_code(codes: List[int]) -> int:
     # if even modes, choose lowest (North)
     target_hemisphere = min(multimode(hemispheres))
 
-    zones = [c % 100 for c in codes]
-    # if even modes, choose lowest
-    target_zone = min(multimode(zones))
+    zones = sorted([c % 100 for c in codes])
+    # if even length, choose fist of median two
+    target_zone = zones[len(zones) // 2]
 
     return target_hemisphere + target_zone
 

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -24,14 +24,14 @@ def test_get_target_epsg_code():
 
     # both hemispheres
     assert composite.get_target_epsg_code([32601, 32702]) == 32601
-    assert composite.get_target_epsg_code([32702, 32601]) == 32701
+    assert composite.get_target_epsg_code([32702, 32601]) == 32601
 
     # Southern hemisphere
     assert composite.get_target_epsg_code([32760]) == 32760
-    assert composite.get_target_epsg_code([32730, 32732]) == 32731
+    assert composite.get_target_epsg_code([32730, 32732]) == 32730
 
     # antimeridian
-    assert composite.get_target_epsg_code([32701, 32760]) == 32760
+    assert composite.get_target_epsg_code([32701, 32760]) == 32701
     assert composite.get_target_epsg_code([32701, 32760, 32701]) == 32701
     assert composite.get_target_epsg_code([32701, 32760, 32760]) == 32760
 


### PR DESCRIPTION
* use `multimode` to determine hemisphere; in the event of a tie, choose lowest valued (North).
* re-implement median to choose lowest zone of median two when an even number of zones are given
* no numpy dep. for this now