### PR TITLE
use AVERAGE overview resampling for better nodata handling

### DIFF
--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -145,7 +145,8 @@ def write_cog(file_name: str, data: np.ndarray, transform: List[float], projecti
         temp_geotiff.SetProjection(projection)
 
         driver = gdal.GetDriverByName('COG')
-        driver.CreateCopy(file_name, temp_geotiff, options=['COMPRESS=LZW', 'NUM_THREADS=ALL_CPUS', 'BIGTIFF=YES'])
+        options = ['COMPRESS=LZW', 'OVERVIEW_RESAMPLING=AVERAGE', 'NUM_THREADS=ALL_CPUS', 'BIGTIFF=YES']
+        driver.CreateCopy(file_name, temp_geotiff, options=options)
 
         del temp_geotiff  # How to close w/ gdal
 


### PR DESCRIPTION
This removes the large nodata regions from overviews.  See descriptions of resampling methods at https://gdal.org/programs/gdaladdo.html#cmdoption-gdaladdo-r

hyp3lib.make_cogs previously used `-r average` when generating overviews as well.

For reference, this list of all creation options for the COG driver are at https://gdal.org/drivers/raster/cog.html#creation-options