### PR TITLE
CLI improvements

### DIFF
--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -4,7 +4,7 @@ Create a composite mosaic from a set of Sentinel-1 RTC products using
 local area weighting (D. Small, 2012). Output pixel values are calculated using
 weights that are the inverse of the scattering area. The mosaic is created as a
 Cloud Optimized GeoTIFF (COG). Additionally, a COG specifying the number of
-rasters contributing to each moasic pixel is created.
+rasters contributing to each mosaic pixel is created.
 
 References:
     David Small, 2012: https://doi.org/10.1109/IGARSS.2012.6350465

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -21,6 +21,7 @@ from typing import List
 import numpy as np
 from osgeo import gdal, osr
 
+gdal.UseExceptions()
 log = logging.getLogger(__name__)
 
 
@@ -163,6 +164,8 @@ def make_composite(out_name: str, rasters: List[str], resolution: float = None):
     raster_info = {}
     for raster in rasters:
         raster_info[raster] = gdal.Info(raster, format='json')
+        if not os.path.exists(area_raster := get_area_raster(raster)):
+            raise FileNotFoundError(f'Could not find area raster {area_raster}')
 
     target_epsg_code = get_target_epsg_code([get_epsg_code(info) for info in raster_info.values()])
     log.debug(f'Composite projection is EPSG:{target_epsg_code}')

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -154,6 +154,7 @@ def write_cog(file_name: str, data: np.ndarray, transform: List[float], projecti
         driver.CreateCopy(file_name, temp_geotiff, options=options)
 
         del temp_geotiff  # How to close w/ gdal
+        return file_name
 
 
 def make_composite(out_name: str, rasters: List[str], resolution: float = None):
@@ -224,12 +225,10 @@ def make_composite(out_name: str, rasters: List[str], resolution: float = None):
     outputs /= weights
     del weights
 
-    out_raster = f'{out_name}.tif'
-    write_cog(out_raster, outputs, full_trans, full_proj, nodata_value=0)
+    out_raster = write_cog(f'{out_name}.tif', outputs, full_trans, full_proj, nodata_value=0)
     del outputs
 
-    out_counts_raster = f'{out_name}_counts.tif'
-    write_cog(out_counts_raster, counts, full_trans, full_proj, dtype=gdal.GDT_Int16)
+    out_counts_raster = write_cog(f'{out_name}_counts.tif', counts, full_trans, full_proj, dtype=gdal.GDT_Int16)
     del counts
 
     return out_raster, out_counts_raster

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -1,10 +1,10 @@
-"""Create an inverse area weighted composite mosaic from Sentinel-1 RTC products.
+"""Create an inverse scattering area weighted composite from Sentinel-1 RTC products.
 
-Create a composite mosaic from a set of Sentinel-1 RTC products using
-local area weighting (D. Small, 2012). Output pixel values are calculated using
-weights that are the inverse of the scattering area. The mosaic is created as a
-Cloud Optimized GeoTIFF (COG). Additionally, a COG specifying the number of
-rasters contributing to each mosaic pixel is created.
+Create an inverse scattering area weighted composite from a set of Sentinel-1 RTC
+products (D. Small, 2012). Output pixel values are calculated using weights that
+are the inverse of the scattering area for that pixel. The composite image is
+created as a Cloud Optimized GeoTIFF (COG). Additionally, a COG specifying the
+number of rasters contributing to each composite pixel is created.
 
 References:
     David Small, 2012: https://doi.org/10.1109/IGARSS.2012.6350465
@@ -32,7 +32,7 @@ def get_epsg_code(info: dict) -> int:
 
 
 def get_target_epsg_code(codes: List[int]) -> int:
-    """Determine the target UTM EPSG projection for the output mosaic
+    """Determine the target UTM EPSG projection for the output composite
 
     Args:
         codes: List of UTM EPSG codes
@@ -156,9 +156,9 @@ def write_cog(file_name: str, data: np.ndarray, transform: List[float], projecti
 
 
 def make_composite(out_name: str, rasters: List[str], resolution: float = None):
-    """Create a composite mosaic of rasters using inverse area weighting to adjust backscatter"""
+    """Create an inverse scattering area weighted composite from Sentinel-1 RTC products"""
     if not rasters:
-        raise ValueError('Must specify at least one raster to mosaic')
+        raise ValueError('Must specify at least one raster to composite')
 
     raster_info = {}
     for raster in rasters:
@@ -237,8 +237,8 @@ def main():
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument('out_name', help='Base name of output mosaic GeoTIFF (without extension)')
-    parser.add_argument('rasters', nargs='+', help='Sentinel-1 GeoTIFF rasters to mosaic')
+    parser.add_argument('out_name', help='Base name of output composite GeoTIFF (without extension)')
+    parser.add_argument('rasters', nargs='+', help='Sentinel-1 GeoTIFF rasters to composite')
     parser.add_argument('-r', '--resolution', type=float,
                         help='Desired output resolution in meters '
                              '(default is the max resolution of all the input files)')
@@ -248,9 +248,9 @@ def main():
     level = logging.DEBUG if args.verbose else logging.INFO
     logging.basicConfig(stream=sys.stdout, format='%(asctime)s - %(levelname)s - %(message)s', level=level)
     log.debug(' '.join(sys.argv))
-    log.info(f'Creating mosaic of {len(args.rasters)} rasters')
+    log.info(f'Creating a composite of {len(args.rasters)} rasters')
 
     raster, counts = make_composite(args.out_name, args.rasters, args.resolution)
 
-    log.info(f'Moasic created successfully: {raster}')
+    log.info(f'Composite created successfully: {raster}')
     log.info(f'Number of rasters contributing to each pixel: {counts}')

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -158,7 +158,7 @@ def write_cog(file_name: str, data: np.ndarray, transform: List[float], projecti
 def make_composite(out_name: str, rasters: List[str], resolution: float = None):
     """Create a composite mosaic of rasters using inverse area weighting to adjust backscatter"""
     if not rasters:
-        raise ValueError(f'Must specify at least one raster to mosaic')
+        raise ValueError('Must specify at least one raster to mosaic')
 
     raster_info = {}
     for raster in rasters:

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -157,6 +157,9 @@ def write_cog(file_name: str, data: np.ndarray, transform: List[float], projecti
 
 def make_composite(out_name: str, rasters: List[str], resolution: float = None):
     """Create a composite mosaic of rasters using inverse area weighting to adjust backscatter"""
+    if not rasters:
+        raise ValueError(f'Must specify at least one raster to mosaic')
+
     raster_info = {}
     for raster in rasters:
         raster_info[raster] = gdal.Info(raster, format='json')

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -165,8 +165,8 @@ def make_composite(out_name: str, rasters: List[str], resolution: float = None):
     raster_info = {}
     for raster in rasters:
         raster_info[raster] = gdal.Info(raster, format='json')
-        if not os.path.exists(area_raster := get_area_raster(raster)):
-            raise FileNotFoundError(f'Could not find area raster {area_raster}')
+        # make sure gdal can read the area raster
+        gdal.Info(get_area_raster(raster))
 
     target_epsg_code = get_target_epsg_code([get_epsg_code(info) for info in raster_info.values()])
     log.debug(f'Composite projection is EPSG:{target_epsg_code}')


### PR DESCRIPTION
* Descriptive docstring for composite module; also used as CLI description
* drop `--path` and `--pol` arguments in favor of users selecting their own input files
* `rasters` (previously `infiles`) is now a required positional argument that needs at least 1 raster
* `make_composite` function raises a `ValueError` when no input rasters provided
* argument names and `make_composite` function arguments are now uniform

Minor things:
* cleaned up some of the logging in `main`
* double -> single quote strings in main 

Current CLI `--help`:
```
usage: make_composite.py [-h] [-r RESOLUTION] [-v] out_name rasters [rasters ...]

Create an inverse area weighted composite mosaic from Sentinel-1 RTC products.

Create a composite mosaic from a set of Sentinel-1 RTC products using
local area weighting (D. Small, 2012). Output pixel values are calculated using
weights that are the inverse of the scattering area. The mosaic is created as a
Cloud Optimized GeoTIFF (COG). Additionally, a COG specifying the number of
rasters contributing to each moasic pixel is created.

References:
    David Small, 2012: https://doi.org/10.1109/IGARSS.2012.6350465

positional arguments:
  out_name              Base name of output mosaic GeoTIFF (without extension)
  rasters               Sentinel-1 GeoTIFF rasters to mosaic

optional arguments:
  -h, --help            show this help message and exit
  -r RESOLUTION, --resolution RESOLUTION
                        Desired output resolution in meters (default is the max resolution of all the input files)
  -v, --verbose         Turn on verbose logging
```