### PR TITLE
send logs to stdout, reduce number of log.info messages

### DIFF
--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -11,9 +11,9 @@
 import argparse
 import logging
 import os
+import sys
 from glob import glob
 from statistics import multimode
-from sys import argv
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import List
 
@@ -250,8 +250,8 @@ def main():
     args = parser.parse_args()
 
     level = logging.DEBUG if args.verbose else logging.INFO
-    logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', level=level)
-    log.debug(' '.join(argv))
+    logging.basicConfig(stream=sys.stdout, format='%(asctime)s - %(levelname)s - %(message)s', level=level)
+    log.debug(' '.join(sys.argv))
     log.info("Starting run")
 
     rasters = get_rasters_from_path(args.path, args.pol) if args.path else args.infiles


### PR DESCRIPTION
Here's the example default output.  Setting `--verbose` or `level=logging.DEBUG` still gets you most of the old messages.
```
2020-12-01 11:43:17,137 - INFO - Starting run
2020-12-01 11:43:17,164 - INFO - Reprojecting S1A_IW_20181102T155531_DVP_RTC30_G_gpuned_5685/S1A_IW_20181102T155531_DVP_RTC30_G_gpuned_5685_VV.tif
2020-12-01 11:43:20,326 - INFO - Reprojecting S1A_IW_20181102T155531_DVP_RTC30_G_gpuned_5685/S1A_IW_20181102T155531_DVP_RTC30_G_gpuned_5685_area.tif
2020-12-01 11:43:23,519 - INFO - Reprojecting S1A_IW_20181102T155556_DVP_RTC30_G_gpuned_7C8B/S1A_IW_20181102T155556_DVP_RTC30_G_gpuned_7C8B_VV.tif
2020-12-01 11:43:26,711 - INFO - Reprojecting S1A_IW_20181102T155556_DVP_RTC30_G_gpuned_7C8B/S1A_IW_20181102T155556_DVP_RTC30_G_gpuned_7C8B_area.tif
2020-12-01 11:43:29,870 - INFO - Reprojecting S1A_IW_20181110T162832_DVP_RTC30_G_gpuned_AAB4/S1A_IW_20181110T162832_DVP_RTC30_G_gpuned_AAB4_VV.tif
2020-12-01 11:43:32,778 - INFO - Reprojecting S1A_IW_20181110T162832_DVP_RTC30_G_gpuned_AAB4/S1A_IW_20181110T162832_DVP_RTC30_G_gpuned_AAB4_area.tif
2020-12-01 11:43:35,772 - INFO - Reprojecting S1A_IW_20181110T162857_DVP_RTC30_G_gpuned_1168/S1A_IW_20181110T162857_DVP_RTC30_G_gpuned_1168_VV.tif
2020-12-01 11:43:38,830 - INFO - Reprojecting S1A_IW_20181110T162857_DVP_RTC30_G_gpuned_1168/S1A_IW_20181110T162857_DVP_RTC30_G_gpuned_1168_area.tif
2020-12-01 11:43:42,189 - INFO - Reprojecting S1A_IW_20181110T162922_DVP_RTC30_G_gpuned_2345/S1A_IW_20181110T162922_DVP_RTC30_G_gpuned_2345_VV.tif
2020-12-01 11:43:45,159 - INFO - Reprojecting S1A_IW_20181110T162922_DVP_RTC30_G_gpuned_2345/S1A_IW_20181110T162922_DVP_RTC30_G_gpuned_2345_area.tif
2020-12-01 11:43:48,195 - INFO - No need to reproject S1A_IW_20181112T161236_DVP_RTC30_G_gpuned_EE18/S1A_IW_20181112T161236_DVP_RTC30_G_gpuned_EE18_VV.tif
2020-12-01 11:43:48,195 - INFO - No need to reproject S1A_IW_20181112T161301_DVP_RTC30_G_gpuned_79E1/S1A_IW_20181112T161301_DVP_RTC30_G_gpuned_79E1_VV.tif
2020-12-01 11:43:48,195 - INFO - Processing raster /tmp/reprojected_76z_o94p/S1A_IW_20181102T155531_DVP_RTC30_G_gpuned_5685_VV.tif
/home/asjohnston/src/asf-tools/asf_tools/composite.py:206: RuntimeWarning: divide by zero encountered in true_divide
  raster_weights = 1.0 / areas
2020-12-01 11:43:49,955 - INFO - Processing raster /tmp/reprojected_76z_o94p/S1A_IW_20181102T155556_DVP_RTC30_G_gpuned_7C8B_VV.tif
2020-12-01 11:43:51,576 - INFO - Processing raster /tmp/reprojected_76z_o94p/S1A_IW_20181110T162832_DVP_RTC30_G_gpuned_AAB4_VV.tif
2020-12-01 11:43:53,143 - INFO - Processing raster /tmp/reprojected_76z_o94p/S1A_IW_20181110T162857_DVP_RTC30_G_gpuned_1168_VV.tif
2020-12-01 11:43:54,617 - INFO - Processing raster /tmp/reprojected_76z_o94p/S1A_IW_20181110T162922_DVP_RTC30_G_gpuned_2345_VV.tif
2020-12-01 11:43:56,347 - INFO - Processing raster S1A_IW_20181112T161236_DVP_RTC30_G_gpuned_EE18/S1A_IW_20181112T161236_DVP_RTC30_G_gpuned_EE18_VV.tif
2020-12-01 11:44:00,100 - INFO - Processing raster S1A_IW_20181112T161301_DVP_RTC30_G_gpuned_79E1/S1A_IW_20181112T161301_DVP_RTC30_G_gpuned_79E1_VV.tif
/home/asjohnston/src/asf-tools/asf_tools/composite.py:216: RuntimeWarning: invalid value encountered in true_divide
  outputs /= weights
2020-12-01 11:44:05,578 - INFO - Writing out.tif
2020-12-01 11:44:29,003 - INFO - Writing out_counts.tif
2020-12-01 11:44:36,177 - INFO - Program successfully completed
```