### PR TITLE
Update README and hyp3-docs workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Build release asset names
         id: release_assets
         run: |
+          echo ::set-output name=version_tag::${GITHUB_REF#refs/tags/}
           echo ::set-output name=ARC_FILE::ASF_ArcGIS_Toolbox_$(echo ${GITHUB_REF#refs/tags/}).zip
 
       - name: Zip ArcGIS Toolbox
@@ -35,13 +36,14 @@ jobs:
           args: |
             ${{ steps.release_assets.outputs.ARC_FILE }}
 
-      - name: Trigger rebuild of HyP3 docs
+      - name: Bump ASF Tools version in HyP3 docs
         uses: benc-uk/workflow-dispatch@v1.1
         with:
-          workflow: Deploy to Github.io
+          workflow: Update ASF Tools version
           token: ${{ secrets.TOOLS_BOT_PAK }}
           repo: ASFHyP3/ASFHyP3
           ref: main
+          inputs: '{"asf_tools_version": "${{ steps.release_assets.outputs.version_tag }}"}'
 
       - name: Attempt fast-forward develop from main
         run: |

--- a/asf_tools/README.md
+++ b/asf_tools/README.md
@@ -1,4 +1,4 @@
-## ASF Tools for Python
+# ASF Tools for Python
 
 [![PyPI license](https://img.shields.io/pypi/l/asf_tools.svg)](https://pypi.python.org/pypi/asf_tools/)
 [![PyPI pyversions](https://img.shields.io/pypi/pyversions/asf_tools.svg)](https://pypi.python.org/pypi/asf_tools/)

--- a/asf_tools/README.md
+++ b/asf_tools/README.md
@@ -16,8 +16,8 @@ potential to be used with a variety of rasters, including non-SAR datasets.
 
 ## Install
 
-In order to easily manage dependencies, we recommend using dedicated environments
-for projects via [Anaconda/Miniconda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html).
+In order to easily manage dependencies, we recommend using dedicated project
+environments via [Anaconda/Miniconda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html).
 It is also possible to use [Python virtual environments](https://docs.python.org/3/tutorial/venv.html),
 but installation of non-python dependencies (e.g., `gdal`) can be challenging. 
 

--- a/asf_tools/README.md
+++ b/asf_tools/README.md
@@ -16,13 +16,18 @@ potential to be used with a variety of rasters, including non-SAR datasets.
 
 ## Install
 
-`asf_tools` can be installed via [Anaconda/Miniconda](https://docs.conda.io/en/latest/index.html):
+In order to easily manage dependencies, we recommend using dedicated environments
+for projects via [Anaconda/Miniconda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html).
+It is also possible to use [Python virtual environments](https://docs.python.org/3/tutorial/venv.html),
+but installation of non-python dependencies (e.g., `gdal`) can be challenging. 
+
+`asf_tools` can be installed into a conda environment with
 
 ```
 conda install -c conda-forge asf_tools
 ```
 
-Or using [`pip`](https://pypi.org/project/asf_tools/):
+or into a virtual environment with
 
 ```
 python -m pip install asf_tools

--- a/asf_tools/composite.py
+++ b/asf_tools/composite.py
@@ -8,7 +8,7 @@ is created as a Cloud Optimized GeoTIFF (COG). Additionally, a COG specifying
 the number of rasters contributing to each composite pixel is created.
 
 References:
-    David Small, 2012: https://doi.org/10.1109/IGARSS.2012.6350465
+    David Small, 2012: <https://doi.org/10.1109/IGARSS.2012.6350465>
 """
 
 import argparse


### PR DESCRIPTION
* Adds more information about environments to installation
* Fixes page title heading size
* updates the release workflow to use the `bump ASF Tools version` workflow dispatch, which will be available with ASFHyP3/ASFHyP3#41