### PR TITLE
Array tiling and untiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0](https://github.com/ASFHyP3/asf-tools/compare/v0.2.0...v0.3.0)
+
+### Added
+* `util.tile_array` and `util.untile_array` to transform a numpy array into a set of tiles
+
+
 ## [0.2.0](https://github.com/ASFHyP3/asf-tools/compare/v0.1.1...v0.2.0)
 
 ### Added

--- a/asf_tools/util.py
+++ b/asf_tools/util.py
@@ -89,9 +89,9 @@ def untile_array(tiled_array, array_shape: Tuple[int, int]):
 
     Args:
         tiled_array: a tiled array
-        array_shape: shape to untile the array to. If the untiled array's shape is larger
-            than this, `untile_array` will assume the original image was right-bottom padded
-            to evenly tile, and the padding will be removed.
+        array_shape: shape to untile the array to. If array_shape's size is smaller
+            than the tiled array, `untile_array` will subset the tiled array assuming
+            bottom right padding was added when tiling.
 
     Returns:
         the untiled array

--- a/asf_tools/util.py
+++ b/asf_tools/util.py
@@ -39,15 +39,9 @@ def tile_array(array: np.ndarray, tile_shape: Tuple[int, int] = (200, 200), pad_
     array_rows, array_columns = array.shape
     tile_rows, tile_columns = tile_shape
 
-    if rmod := array_rows % tile_rows:
-        rpad = tile_rows - rmod
-    else:
-        rpad = 0
-
-    if cmod := array_columns % tile_columns:
-        cpad = tile_columns - cmod
-    else:
-        cpad = 0
+    # CREDIT: https://twitter.com/LizzUltee/status/1379508448262512641
+    rpad = -array_rows % tile_rows
+    cpad = -array_columns % tile_columns
 
     if rpad or cpad:
         if pad_value is None:

--- a/asf_tools/util.py
+++ b/asf_tools/util.py
@@ -87,7 +87,7 @@ def untile_array(tiled_array, array_shape: Tuple[int, int]):
 
     Args:
         tiled_array: a tiled array
-        array_shape: shape to until the array to. If the untiled array's shape is larger
+        array_shape: shape to untile the array to. If the untiled array's shape is larger
             than this, `untile_array` will assume the original image was right-bottom padded
             to evenly tile, and the padding will be removed.
 
@@ -109,6 +109,6 @@ def untile_array(tiled_array, array_shape: Tuple[int, int]):
 
     for ii in range(nr):
         for jj in range(nc):
-            untiled[ii*tr:(ii+1)*tr,jj*tc:(jj+1)*tc] = tiled_array[ii * nr + jj, :, :]
+            untiled[ii*tr:(ii+1)*tr, jj*tc:(jj+1)*tc] = tiled_array[ii * nr + jj, :, :]
 
-    return untiled[:ar,:ac]
+    return untiled[:ar, :ac]

--- a/asf_tools/util.py
+++ b/asf_tools/util.py
@@ -3,60 +3,61 @@ from typing import Tuple
 import numpy as np
 
 
-def tile_array(a: np.ndarray, tile_shape: Tuple[int, int] = (200, 200), pad: float = None):
+def tile_array(array: np.ndarray, tile_shape: Tuple[int, int] = (200, 200), pad: float = None):
     """Tile a 2D numpy array
 
     Turn a 2D numpy array like:
-        >>> a = [[0,0,1,1],
-                 [0,0,1,1],
-                 [2,2,3,3],
-                 [2,2,3,3]]
-        >>> a.shape
-        (4,4)
+        >>> array = [[0, 0, 1, 1],
+        ...          [0, 0, 1, 1],
+        ...          [2, 2, 3, 3],
+        ...          [2, 2, 3, 3]]
+        >>> array.shape
+        (4, 4)
 
     into a tiled array like:
-        >>> t = tiled_array(a, 2, 2)
-        >>> t = [[[0,0],
-                  [0,0]],
-                 [[1,1],
-                  [1,1]],
-                 [[2,2],
-                  [2,2]],
-                 [[3,3],
-                  [3,3]]]
-        >>> t.shape
+        >>> tiles = tiled_array(array, 2, 2)
+        >>> print(tiles)
+        [[[0, 0],
+          [0, 0]],
+         [[1, 1],
+          [1, 1]],
+         [[2, 2],
+          [2, 2]],
+         [[3, 3],
+          [3, 3]]]
+        >>> tiles.shape
         (4, 2, 2)
 
     Args:
-        a: 2D array to tile
+        array: 2D array to tile
         tile_shape: the shape of each tile
         pad: right-bottom pad `a` with `pad` as needed so `a` is evenly divisible into tiles
 
     Returns:
-        tiled: the tiled array
+        the tiled array
     """
-    ar, ac = a.shape
-    tr, tc = tile_shape
+    array_rows, array_columns = array.shape
+    tile_rows, tile_columns = tile_shape
 
-    if rmod := ar % tr:
-        rpad = tr - rmod
+    if rmod := array_rows % tile_rows:
+        rpad = tile_rows - rmod
     else:
         rpad = 0
 
-    if cmod := ac % tc:
-        cpad = tc - cmod
+    if cmod := array_columns % tile_columns:
+        cpad = tile_columns - cmod
     else:
         cpad = 0
 
     if rmod or cmod:
         if pad is None:
-            raise ValueError(f'Cannot evenly tile a {a.shape} array into ({tr},{tc}) tiles')
+            raise ValueError(f'Cannot evenly tile a {array.shape} array into ({tile_rows},{tile_columns}) tiles')
         else:
-            a = np.pad(a, ((0, rpad), (0, cpad)), constant_values=pad)
+            array = np.pad(array, ((0, rpad), (0, cpad)), constant_values=pad)
 
     tile_list = []
-    for rows in np.vsplit(a, range(tr, ar, tr)):
-        tile_list.extend(np.hsplit(rows, range(tc, ac, tc)))
+    for rows in np.vsplit(array, range(tile_rows, array_rows, tile_rows)):
+        tile_list.extend(np.hsplit(rows, range(tile_columns, array_columns, tile_columns)))
     tiled = np.moveaxis(np.dstack(tile_list), -1, 0)
     return tiled
 
@@ -65,25 +66,26 @@ def untile_array(tiled_array, array_shape: Tuple[int, int]):
     """Untile a tiled array into a 2D numpy array
 
     This is the reverse of `tile_array` and will turn a tiled array like:
-        >>> t = [[[0,0],
-                  [0,0]],
-                 [[1,1],
-                  [1,1]],
-                 [[2,2],
-                  [2,2]],
-                 [[3,3],
-                  [3,3]]]
+        >>> tiled_array = [[[0,0],
+        ...                 [0,0]],
+        ...                [[1,1],
+        ...                 [1,1]],
+        ...                [[2,2],
+        ...                 [2,2]],
+        ...                [[3,3],
+        ...                 [3,3]]]
         >>> tiled_array.shape
         (4, 2, 2)
 
     into a 2D array like:
-        >>> a = untile_array(t)
-        >>> a = [[0,0,1,1],
-                 [0,0,1,1],
-                 [2,2,3,3],
-                 [2,2,3,3]]
-        >>> a.shape
-        (4,4)
+        >>> array = untile_array(tiled_array)
+        >>> print(array)
+        [[0, 0, 1, 1],
+         [0, 0, 1, 1],
+         [2, 2, 3, 3],
+         [2, 2, 3, 3]]
+        >>> array.shape
+        (4, 4)
 
     Args:
         tiled_array: a tiled array
@@ -92,23 +94,24 @@ def untile_array(tiled_array, array_shape: Tuple[int, int]):
             to evenly tile, and the padding will be removed.
 
     Returns:
-        untiled: the untiled array
+        the untiled array
     """
-    nt, tr, tc = tiled_array.shape
-    ar, ac = array_shape
+    _, tile_rows, tile_columns = tiled_array.shape
+    array_rows, array_columns = array_shape
 
-    nr = int(np.ceil(ar / tr))
-    nc = int(np.ceil(ac / tc))
+    untiled_rows = int(np.ceil(array_rows / tile_rows))
+    untiled_columns = int(np.ceil(array_columns / tile_columns))
 
-    untiled = np.zeros((nr*tr, nc*tc), dtype=tiled_array.dtype)
+    untiled = np.zeros((untiled_rows*tile_rows, untiled_columns*tile_columns), dtype=tiled_array.dtype)
 
-    if ar > untiled.shape[0] or ac > untiled.shape[1]:
+    if array_rows > untiled.shape[0] or array_columns > untiled.shape[1]:
         raise ValueError(
             f'array_shape {array_shape} must be the same or smaller than the untiled array {untiled.shape}'
         )
 
-    for ii in range(nr):
-        for jj in range(nc):
-            untiled[ii*tr:(ii+1)*tr, jj*tc:(jj+1)*tc] = tiled_array[ii * nr + jj, :, :]
+    for ii in range(untiled_rows):
+        for jj in range(untiled_columns):
+            untiled[ii*tile_rows:(ii+1)*tile_rows, jj*tile_columns:(jj+1)*tile_columns] = \
+                tiled_array[ii * untiled_rows + jj, :, :]
 
-    return untiled[:ar, :ac]
+    return untiled[:array_rows, :array_columns]

--- a/asf_tools/util.py
+++ b/asf_tools/util.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import numpy as np
 
 
-def tile_array(array: np.ndarray, tile_shape: Tuple[int, int] = (200, 200), pad: float = None):
+def tile_array(array: np.ndarray, tile_shape: Tuple[int, int] = (200, 200), pad_value: float = None):
     """Tile a 2D numpy array
 
     Turn a 2D numpy array like:
@@ -31,7 +31,7 @@ def tile_array(array: np.ndarray, tile_shape: Tuple[int, int] = (200, 200), pad:
     Args:
         array: 2D array to tile
         tile_shape: the shape of each tile
-        pad: right-bottom pad `a` with `pad` as needed so `a` is evenly divisible into tiles
+        pad_value: right-bottom pad `a` with `pad` as needed so `a` is evenly divisible into tiles
 
     Returns:
         the tiled array
@@ -50,10 +50,10 @@ def tile_array(array: np.ndarray, tile_shape: Tuple[int, int] = (200, 200), pad:
         cpad = 0
 
     if rmod or cmod:
-        if pad is None:
+        if pad_value is None:
             raise ValueError(f'Cannot evenly tile a {array.shape} array into ({tile_rows},{tile_columns}) tiles')
         else:
-            array = np.pad(array, ((0, rpad), (0, cpad)), constant_values=pad)
+            array = np.pad(array, ((0, rpad), (0, cpad)), constant_values=pad_value)
 
     tile_list = []
     for rows in np.vsplit(array, range(tile_rows, array_rows, tile_rows)):

--- a/asf_tools/util.py
+++ b/asf_tools/util.py
@@ -1,7 +1,9 @@
+from typing import Tuple
+
 import numpy as np
 
 
-def tile_array(a, tile_shape=(200, 200), pad=None):
+def tile_array(a: np.ndarray, tile_shape: Tuple[int, int] = (200, 200), pad: float = None):
     """Tile a 2D numpy array
 
     Turn a 2D numpy array like:
@@ -59,7 +61,7 @@ def tile_array(a, tile_shape=(200, 200), pad=None):
     return tiled
 
 
-def untile_array(t, array_shape):
+def untile_array(tiled_array, array_shape: Tuple[int, int]):
     """Untile a tiled array into a 2D numpy array
 
     This is the reverse of `tile_array` and will turn a tiled array like:
@@ -71,7 +73,7 @@ def untile_array(t, array_shape):
                   [2,2]],
                  [[3,3],
                   [3,3]]]
-        >>> t.shape
+        >>> tiled_array.shape
         (4, 2, 2)
 
     into a 2D array like:
@@ -84,7 +86,7 @@ def untile_array(t, array_shape):
         (4,4)
 
     Args:
-        t: a tiled array
+        tiled_array: a tiled array
         array_shape: shape to until the array to. If the untiled array's shape is larger
             than this, `untile_array` will assume the original image was right-bottom padded
             to evenly tile, and the padding will be removed.
@@ -92,13 +94,13 @@ def untile_array(t, array_shape):
     Returns:
         untiled: the untiled array
     """
-    nt, tr, tc = t.shape
+    nt, tr, tc = tiled_array.shape
     ar, ac = array_shape
 
     nr = int(np.ceil(ar / tr))
     nc = int(np.ceil(ac / tc))
 
-    untiled = np.zeros((nr*tr, nc*tc), dtype=t.dtype)
+    untiled = np.zeros((nr*tr, nc*tc), dtype=tiled_array.dtype)
 
     if ar > untiled.shape[0] or ac > untiled.shape[1]:
         raise ValueError(
@@ -107,6 +109,6 @@ def untile_array(t, array_shape):
 
     for ii in range(nr):
         for jj in range(nc):
-            untiled[ii*tr:(ii+1)*tr,jj*tc:(jj+1)*tc] = t[ii*nr+jj,:,:]
+            untiled[ii*tr:(ii+1)*tr,jj*tc:(jj+1)*tc] = tiled_array[ii * nr + jj, :, :]
 
     return untiled[:ar,:ac]

--- a/asf_tools/util.py
+++ b/asf_tools/util.py
@@ -1,0 +1,112 @@
+import numpy as np
+
+
+def tile_array(a, tile_shape=(200, 200), pad=None):
+    """Tile a 2D numpy array
+
+    Turn a 2D numpy array like:
+        >>> a = [[0,0,1,1],
+                 [0,0,1,1],
+                 [2,2,3,3],
+                 [2,2,3,3]]
+        >>> a.shape
+        (4,4)
+
+    into a tiled array like:
+        >>> t = tiled_array(a, 2, 2)
+        >>> t = [[[0,0],
+                  [0,0]],
+                 [[1,1],
+                  [1,1]],
+                 [[2,2],
+                  [2,2]],
+                 [[3,3],
+                  [3,3]]]
+        >>> t.shape
+        (4, 2, 2)
+
+    Args:
+        a: 2D array to tile
+        tile_shape: the shape of each tile
+        pad: right-bottom pad `a` with `pad` as needed so `a` is evenly divisible into tiles
+
+    Returns:
+        tiled: the tiled array
+    """
+    ar, ac = a.shape
+    tr, tc = tile_shape
+
+    if rmod := ar % tr:
+        rpad = tr - rmod
+    else:
+        rpad = 0
+
+    if cmod := ac % tc:
+        cpad = tc - cmod
+    else:
+        cpad = 0
+
+    if rmod or cmod:
+        if pad is None:
+            raise ValueError(f'Cannot evenly tile a {a.shape} array into ({tr},{tc}) tiles')
+        else:
+            a = np.pad(a, ((0, rpad), (0, cpad)), constant_values=pad)
+
+    tile_list = []
+    for rows in np.vsplit(a, range(tr, ar, tr)):
+        tile_list.extend(np.hsplit(rows, range(tc, ac, tc)))
+    tiled = np.moveaxis(np.dstack(tile_list), -1, 0)
+    return tiled
+
+
+def untile_array(t, array_shape):
+    """Untile a tiled array into a 2D numpy array
+
+    This is the reverse of `tile_array` and will turn a tiled array like:
+        >>> t = [[[0,0],
+                  [0,0]],
+                 [[1,1],
+                  [1,1]],
+                 [[2,2],
+                  [2,2]],
+                 [[3,3],
+                  [3,3]]]
+        >>> t.shape
+        (4, 2, 2)
+
+    into a 2D array like:
+        >>> a = untile_array(t)
+        >>> a = [[0,0,1,1],
+                 [0,0,1,1],
+                 [2,2,3,3],
+                 [2,2,3,3]]
+        >>> a.shape
+        (4,4)
+
+    Args:
+        t: a tiled array
+        array_shape: shape to until the array to. If the untiled array's shape is larger
+            than this, `untile_array` will assume the original image was right-bottom padded
+            to evenly tile, and the padding will be removed.
+
+    Returns:
+        untiled: the untiled array
+    """
+    nt, tr, tc = t.shape
+    ar, ac = array_shape
+
+    nr = int(np.ceil(ar / tr))
+    nc = int(np.ceil(ac / tc))
+
+    untiled = np.zeros((nr*tr, nc*tc), dtype=t.dtype)
+
+    if ar > untiled.shape[0] or ac > untiled.shape[1]:
+        raise ValueError(
+            f'array_shape {array_shape} must be the same or smaller than the untiled array {untiled.shape}'
+        )
+
+    for ii in range(nr):
+        for jj in range(nc):
+            untiled[ii*tr:(ii+1)*tr,jj*tc:(jj+1)*tc] = t[ii*nr+jj,:,:]
+
+    return untiled[:ar,:ac]

--- a/asf_tools/util.py
+++ b/asf_tools/util.py
@@ -104,14 +104,15 @@ def untile_array(tiled_array, array_shape: Tuple[int, int]):
 
     untiled = np.zeros((untiled_rows*tile_rows, untiled_columns*tile_columns), dtype=tiled_array.dtype)
 
-    try:
-        for ii in range(untiled_rows):
-            for jj in range(untiled_columns):
-                untiled[ii*tile_rows:(ii+1)*tile_rows, jj*tile_columns:(jj+1)*tile_columns] = \
-                    tiled_array[ii * untiled_rows + jj, :, :]
-    except IndexError:
+    if (array_size := array_rows * array_columns) > tiled_array.size:
         raise ValueError(
-            f'Unable to untile the array using the input array_shape {array_shape}.'
+            f'array_shape {array_shape} will result in an array bigger than the tiled array:'
+            f' {array_size} > {tiled_array.size}'
         )
+
+    for ii in range(untiled_rows):
+        for jj in range(untiled_columns):
+            untiled[ii*tile_rows:(ii+1)*tile_rows, jj*tile_columns:(jj+1)*tile_columns] = \
+                tiled_array[ii * untiled_rows + jj, :, :]
 
     return untiled[:array_rows, :array_columns]

--- a/asf_tools/util.py
+++ b/asf_tools/util.py
@@ -49,7 +49,7 @@ def tile_array(array: np.ndarray, tile_shape: Tuple[int, int] = (200, 200), pad_
     else:
         cpad = 0
 
-    if rmod or cmod:
+    if rpad or cpad:
         if pad_value is None:
             raise ValueError(f'Cannot evenly tile a {array.shape} array into ({tile_rows},{tile_columns}) tiles')
         else:

--- a/asf_tools/util.py
+++ b/asf_tools/util.py
@@ -104,14 +104,14 @@ def untile_array(tiled_array, array_shape: Tuple[int, int]):
 
     untiled = np.zeros((untiled_rows*tile_rows, untiled_columns*tile_columns), dtype=tiled_array.dtype)
 
-    if array_rows > untiled.shape[0] or array_columns > untiled.shape[1]:
+    try:
+        for ii in range(untiled_rows):
+            for jj in range(untiled_columns):
+                untiled[ii*tile_rows:(ii+1)*tile_rows, jj*tile_columns:(jj+1)*tile_columns] = \
+                    tiled_array[ii * untiled_rows + jj, :, :]
+    except IndexError:
         raise ValueError(
-            f'array_shape {array_shape} must be the same or smaller than the untiled array {untiled.shape}'
+            f'Unable to untile the array using the input array_shape {array_shape}.'
         )
-
-    for ii in range(untiled_rows):
-        for jj in range(untiled_columns):
-            untiled[ii*tile_rows:(ii+1)*tile_rows, jj*tile_columns:(jj+1)*tile_columns] = \
-                tiled_array[ii * untiled_rows + jj, :, :]
 
     return untiled[:array_rows, :array_columns]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from asf_tools import util
+
+
+def test_tile_array():
+    a = np.array([[0, 0, 1, 1],
+                  [0, 0, 1, 1],
+                  [2, 2, 3, 3],
+                  [2, 2, 3, 3]])
+
+    tiled = util.tile_array(a, tile_shape=(2, 2))
+    assert tiled.shape == (4, 2, 2)
+    assert np.all(tiled[0, :, :] == np.array([[0, 0], [0, 0]]))
+    assert np.all(tiled[-1, :, :] == np.array([[3, 3], [3, 3]]))
+
+    with pytest.raises(ValueError):
+        util.tile_array(a, tile_shape=(3, 3))
+
+    tiled = util.tile_array(a, tile_shape=(3, 3), pad=4)
+    assert tiled.shape == (4, 3, 3)
+    assert np.all(tiled[0, :, :] == np.array([[0, 0, 1], [0, 0, 1], [2, 2, 3]]))
+    assert np.all(tiled[-1, :, :] == np.array([[3, 4, 4], [4, 4, 4], [4, 4, 4]]))
+
+    tiled = util.tile_array(a, tile_shape=(2, 3), pad=4)
+    assert tiled.shape == (4, 2, 3)
+    assert np.all(tiled[0, :, :] == np.array([[0, 0, 1], [0, 0, 1]]))
+    assert np.all(tiled[-1, :, :] == np.array([[3, 4, 4], [3, 4, 4]]))
+
+    tiled = util.tile_array(a, tile_shape=(3, 2), pad=4)
+    assert tiled.shape == (4, 3, 2)
+    assert np.all(tiled[0, :, :] == np.array([[0, 0], [0, 0], [2, 2]]))
+    assert np.all(tiled[-1, :, :] == np.array([[3, 3], [4, 4], [4, 4]]))
+
+
+def test_untile_array():
+    a = np.array([[0, 0, 1, 1],
+                  [0, 0, 1, 1],
+                  [2, 2, 3, 3],
+                  [2, 2, 3, 3]])
+
+    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 2)), array_shape=a.shape))
+    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 3), pad=4), array_shape=a.shape))
+    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 3), pad=4), array_shape=a.shape))
+    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 2), pad=4), array_shape=a.shape))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -40,13 +40,19 @@ def test_untile_array():
                   [2, 2, 3, 3],
                   [2, 2, 3, 3]])
 
-    # assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 2)), array_shape=a.shape))
-    # assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 3), pad_value=4), array_shape=a.shape))
-    # assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 3), pad_value=4), array_shape=a.shape))
-    # assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 2), pad_value=4), array_shape=a.shape))
+    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 2)), array_shape=a.shape))
+    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 3), pad_value=4), array_shape=a.shape))
+    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 3), pad_value=4), array_shape=a.shape))
+    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 2), pad_value=4), array_shape=a.shape))
 
     with pytest.raises(ValueError):
         util.untile_array(util.tile_array(a, tile_shape=(2, 2)), array_shape=(5, 5))
 
     with pytest.raises(ValueError):
-        util.untile_array(util.tile_array(a, tile_shape=(3, 3), pad_value=4), array_shape=(7, 7))
+        util.untile_array(util.tile_array(a, tile_shape=(2, 3), pad_value=4), array_shape=(4, 7))
+
+    # array shape will subset some of the padding that was required to tile `a` with `tile_shape`
+    assert np.all(
+            np.pad(a, ((0, 0), (0, 1)), constant_values=4)
+            == util.untile_array(util.tile_array(a, tile_shape=(2, 3), pad_value=4), array_shape=(4, 5))
+    )

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -40,7 +40,13 @@ def test_untile_array():
                   [2, 2, 3, 3],
                   [2, 2, 3, 3]])
 
-    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 2)), array_shape=a.shape))
-    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 3), pad_value=4), array_shape=a.shape))
-    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 3), pad_value=4), array_shape=a.shape))
-    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 2), pad_value=4), array_shape=a.shape))
+    # assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 2)), array_shape=a.shape))
+    # assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 3), pad_value=4), array_shape=a.shape))
+    # assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 3), pad_value=4), array_shape=a.shape))
+    # assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 2), pad_value=4), array_shape=a.shape))
+
+    with pytest.raises(ValueError):
+        util.untile_array(util.tile_array(a, tile_shape=(2, 2)), array_shape=(5, 5))
+
+    with pytest.raises(ValueError):
+        util.untile_array(util.tile_array(a, tile_shape=(3, 3), pad_value=4), array_shape=(7, 7))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -18,17 +18,17 @@ def test_tile_array():
     with pytest.raises(ValueError):
         util.tile_array(a, tile_shape=(3, 3))
 
-    tiled = util.tile_array(a, tile_shape=(3, 3), pad=4)
+    tiled = util.tile_array(a, tile_shape=(3, 3), pad_value=4)
     assert tiled.shape == (4, 3, 3)
     assert np.all(tiled[0, :, :] == np.array([[0, 0, 1], [0, 0, 1], [2, 2, 3]]))
     assert np.all(tiled[-1, :, :] == np.array([[3, 4, 4], [4, 4, 4], [4, 4, 4]]))
 
-    tiled = util.tile_array(a, tile_shape=(2, 3), pad=4)
+    tiled = util.tile_array(a, tile_shape=(2, 3), pad_value=4)
     assert tiled.shape == (4, 2, 3)
     assert np.all(tiled[0, :, :] == np.array([[0, 0, 1], [0, 0, 1]]))
     assert np.all(tiled[-1, :, :] == np.array([[3, 4, 4], [3, 4, 4]]))
 
-    tiled = util.tile_array(a, tile_shape=(3, 2), pad=4)
+    tiled = util.tile_array(a, tile_shape=(3, 2), pad_value=4)
     assert tiled.shape == (4, 3, 2)
     assert np.all(tiled[0, :, :] == np.array([[0, 0], [0, 0], [2, 2]]))
     assert np.all(tiled[-1, :, :] == np.array([[3, 3], [4, 4], [4, 4]]))
@@ -41,6 +41,6 @@ def test_untile_array():
                   [2, 2, 3, 3]])
 
     assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 2)), array_shape=a.shape))
-    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 3), pad=4), array_shape=a.shape))
-    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 3), pad=4), array_shape=a.shape))
-    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 2), pad=4), array_shape=a.shape))
+    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 3), pad_value=4), array_shape=a.shape))
+    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(2, 3), pad_value=4), array_shape=a.shape))
+    assert np.all(a == util.untile_array(util.tile_array(a, tile_shape=(3, 2), pad_value=4), array_shape=a.shape))


### PR DESCRIPTION
A critical step to surface water extent mapping is breaking a scene down into a set of sub-scenes (tiling), see first figure in:
https://github.com/fjmeyer/HydroSAR/blob/master/HYDRO30Workflow-v1.ipynb

 This adds tiling (and untiling) utility functions to perform that duty. 
