### PR TITLE
Add a scale conversion function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `kittler_illingworth_threshold` in `asf_tools.threshold` to calculate a minimum error threshold
   value à la [Kittler and Illingworth, 1986](https://doi.org/10.1016/0031-3203(86)90030-0)
 * `tile_array` and `untile_array` in `asf_tools.util` to transform a numpy array into a set of tiles
-* `convert_scale` in `asf_tools.raster` to transform between decibel, power, and amplitude scales
+* `convert_scale` in `asf_tools.raster` to transform calibrated raster between decibel, power, and amplitude scales
 
 ## [0.2.0](https://github.com/ASFHyP3/asf-tools/compare/v0.1.1...v0.2.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * `kittler_illingworth_threshold` in `asf_tools.threshold` to calculate a minimum error threshold
   value à la [Kittler and Illingworth, 1986](https://doi.org/10.1016/0031-3203(86)90030-0)
 * `tile_array` and `untile_array` in `asf_tools.util` to transform a numpy array into a set of tiles
-
+* `convert_scale` in `asf_tools.raster` to transform between decibel, power, and amplitude scales
 
 ## [0.2.0](https://github.com/ASFHyP3/asf-tools/compare/v0.1.1...v0.2.0)
 

--- a/asf_tools/raster.py
+++ b/asf_tools/raster.py
@@ -1,0 +1,29 @@
+import warnings
+import numpy as np
+
+
+def convert_scale(array: np.ndarray, in_scale: str, out_scale: str) -> np.ndarray:
+    """Convert raster scale between power, amplitude and db"""
+    if in_scale == out_scale:
+        warnings.warn(f'Nothing to do! {in_scale} is same as {out_scale}.')
+        return array
+
+    if in_scale == 'db':
+        if out_scale == 'power':
+            return 10 ** (array / 10)
+        if out_scale == 'amplitude':
+            return 10 ** (array / 20)
+
+    if in_scale == 'amplitude':
+        if out_scale == 'power':
+            return array ** 2
+        if out_scale == 'db':
+            return 10 * np.log10(array ** 2)
+
+    if in_scale == 'power':
+        if out_scale == 'amplitude':
+            return np.sqrt(array)
+        if out_scale == 'db':
+            return 10 * np.log10(array)
+
+    raise ValueError(f'Cannot convert raster of scale {in_scale} to {out_scale}')

--- a/asf_tools/raster.py
+++ b/asf_tools/raster.py
@@ -6,7 +6,7 @@ import numpy as np
 
 def convert_scale(array: np.ndarray, in_scale: Literal['db', 'amplitude', 'power'],
                   out_scale: Literal['db', 'amplitude', 'power']) -> np.ndarray:
-    """Convert raster scale between power, amplitude and db"""
+    """Convert calibrated raster scale between db, amplitude and power"""
     if in_scale == out_scale:
         warnings.warn(f'Nothing to do! {in_scale} is same as {out_scale}.')
         return array

--- a/asf_tools/raster.py
+++ b/asf_tools/raster.py
@@ -1,8 +1,13 @@
+from typing import Literal
 import warnings
+
+
+
 import numpy as np
 
 
-def convert_scale(array: np.ndarray, in_scale: str, out_scale: str) -> np.ndarray:
+def convert_scale(array: np.ndarray, in_scale: Literal['db', 'amplitude', 'power'],
+                  out_scale: Literal['db', 'amplitude', 'power']) -> np.ndarray:
     """Convert raster scale between power, amplitude and db"""
     if in_scale == out_scale:
         warnings.warn(f'Nothing to do! {in_scale} is same as {out_scale}.')

--- a/asf_tools/raster.py
+++ b/asf_tools/raster.py
@@ -1,7 +1,5 @@
-from typing import Literal
 import warnings
-
-
+from typing import Literal
 
 import numpy as np
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1,0 +1,40 @@
+import numpy as np
+
+import pytest
+
+from asf_tools import raster
+
+def test_convert_scale():
+    c = raster.convert_scale(np.array([-10, -5, 0, 5, 10]), 'amplitude', 'power')
+    assert np.all(np.isclose(np.array([100, 25, 0, 25, 100]), c))
+
+    c = raster.convert_scale(np.array([-10, -5, 0, 5, 10]), 'amplitude', 'db')
+    assert np.all(np.isclose(np.array([20., 13.97940009, -np.inf, 13.97940009, 20.]), c))
+
+    c = raster.convert_scale(np.array([-1, 0, 1, 4, 9]), 'power', 'amplitude')
+    assert np.isnan(c[0])
+    assert np.all(np.isclose(np.array([0, 1, 2, 3]), c[1:]))
+
+    c = raster.convert_scale(np.array([-1, 0, 1, 4, 9]), 'power', 'db')
+    assert np.isnan(c[0])
+    assert np.all(np.isclose(np.array([-np.inf, 0., 6.02059991, 9.54242509]), c[1:]))
+
+    c = raster.convert_scale(np.array([np.nan, -np.inf, 0., 6.02059991, 9.54242509]), 'db', 'power')
+    assert np.isnan(c[0])
+    assert np.all(np.isclose(np.array([0, 1, 4, 9]), c[1:]))
+
+    c = raster.convert_scale(np.array([-np.inf, -20., 0., 13.97940009, 20.]), 'db', 'amplitude')
+    assert np.all(np.isclose(np.array([0., 0.1, 1., 5., 10.]), c))
+
+    a = np.array([-10, -5, 0, 5, 10])
+    with pytest.raises(ValueError):
+        _ = raster.convert_scale(a, 'power', 'foo')
+    with pytest.raises(ValueError):
+        _ = raster.convert_scale(a, 'bar', 'amplitude')
+
+    with pytest.warns(UserWarning):
+        assert np.all(np.array([-10, -5, 0, 5, 10]) == raster.convert_scale(a, 'amplitude', 'amplitude'))
+    with pytest.warns(UserWarning):
+        assert np.all(np.array([-10, -5, 0, 5, 10]) == raster.convert_scale(a, 'power', 'power'))
+    with pytest.warns(UserWarning):
+        assert np.all(np.array([-10, -5, 0, 5, 10]) == raster.convert_scale(a, 'db', 'db'))

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 import pytest
 
 from asf_tools import raster

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -4,6 +4,7 @@ import pytest
 
 from asf_tools import raster
 
+
 def test_convert_scale():
     c = raster.convert_scale(np.array([-10, -5, 0, 5, 10]), 'amplitude', 'power')
     assert np.all(np.isclose(np.array([100, 25, 0, 25, 100]), c))


### PR DESCRIPTION
Will need to switch from Power to db when doing the expectation maximization thresholding.


Of note: This is based on what @hjkristenson did for the ArcGIS toolbox, but doesn't look exactly like the db conversion in the notebooks:

```python
db = np.log10(power)+30
```