### PR TITLE
Allow raster scale conversion to handle masked arrays

### DIFF
--- a/asf_tools/raster.py
+++ b/asf_tools/raster.py
@@ -10,12 +10,14 @@ gdal.UseExceptions()
 log = logging.getLogger(__name__)
 
 
-def convert_scale(array: np.ndarray, in_scale: Literal['db', 'amplitude', 'power'],
-                  out_scale: Literal['db', 'amplitude', 'power']) -> np.ndarray:
+def convert_scale(array: Union[np.ndarray, np.ma.MaskedArray], in_scale: Literal['db', 'amplitude', 'power'],
+                  out_scale: Literal['db', 'amplitude', 'power']) -> Union[np.ndarray, np.ma.MaskedArray]:
     """Convert calibrated raster scale between db, amplitude and power"""
     if in_scale == out_scale:
         warnings.warn(f'Nothing to do! {in_scale} is same as {out_scale}.')
         return array
+
+    log10 = np.ma.log10 if isinstance(array, np.ma.MaskedArray) else np.log10
 
     if in_scale == 'db':
         if out_scale == 'power':
@@ -27,13 +29,13 @@ def convert_scale(array: np.ndarray, in_scale: Literal['db', 'amplitude', 'power
         if out_scale == 'power':
             return array ** 2
         if out_scale == 'db':
-            return 10 * np.log10(array ** 2)
+            return 10 * log10(array ** 2)
 
     if in_scale == 'power':
         if out_scale == 'amplitude':
             return np.sqrt(array)
         if out_scale == 'db':
-            return 10 * np.log10(array)
+            return 10 * log10(array)
 
     raise ValueError(f'Cannot convert raster of scale {in_scale} to {out_scale}')
 

--- a/tests/test_raster.py
+++ b/tests/test_raster.py
@@ -6,25 +6,25 @@ from asf_tools import raster
 
 def test_convert_scale():
     c = raster.convert_scale(np.array([-10, -5, 0, 5, 10]), 'amplitude', 'power')
-    assert np.all(np.isclose(np.array([100, 25, 0, 25, 100]), c))
+    assert np.allclose(c, np.array([100, 25, 0, 25, 100]))
 
     c = raster.convert_scale(np.array([-10, -5, 0, 5, 10]), 'amplitude', 'db')
-    assert np.all(np.isclose(np.array([20., 13.97940009, -np.inf, 13.97940009, 20.]), c))
+    assert np.allclose(c, np.array([20., 13.97940009, -np.inf, 13.97940009, 20.]))
 
     c = raster.convert_scale(np.array([-1, 0, 1, 4, 9]), 'power', 'amplitude')
     assert np.isnan(c[0])
-    assert np.all(np.isclose(np.array([0, 1, 2, 3]), c[1:]))
+    assert np.allclose(c[1:], np.array([0, 1, 2, 3]))
 
     c = raster.convert_scale(np.array([-1, 0, 1, 4, 9]), 'power', 'db')
     assert np.isnan(c[0])
-    assert np.all(np.isclose(np.array([-np.inf, 0., 6.02059991, 9.54242509]), c[1:]))
+    assert np.allclose(c[1:], np.array([-np.inf, 0., 6.02059991, 9.54242509]), )
 
     c = raster.convert_scale(np.array([np.nan, -np.inf, 0., 6.02059991, 9.54242509]), 'db', 'power')
     assert np.isnan(c[0])
-    assert np.all(np.isclose(np.array([0, 1, 4, 9]), c[1:]))
+    assert np.allclose(c[1:], np.array([0, 1, 4, 9]))
 
     c = raster.convert_scale(np.array([-np.inf, -20., 0., 13.97940009, 20.]), 'db', 'amplitude')
-    assert np.all(np.isclose(np.array([0., 0.1, 1., 5., 10.]), c))
+    assert np.allclose(c, np.array([0., 0.1, 1., 5., 10.]))
 
     a = np.array([-10, -5, 0, 5, 10])
     with pytest.raises(ValueError):
@@ -33,8 +33,21 @@ def test_convert_scale():
         _ = raster.convert_scale(a, 'bar', 'amplitude')
 
     with pytest.warns(UserWarning):
-        assert np.all(np.array([-10, -5, 0, 5, 10]) == raster.convert_scale(a, 'amplitude', 'amplitude'))
+        assert np.allclose(raster.convert_scale(a, 'amplitude', 'amplitude'), np.array([-10, -5, 0, 5, 10]))
     with pytest.warns(UserWarning):
-        assert np.all(np.array([-10, -5, 0, 5, 10]) == raster.convert_scale(a, 'power', 'power'))
+        assert np.allclose(raster.convert_scale(a, 'power', 'power'), np.array([-10, -5, 0, 5, 10]))
     with pytest.warns(UserWarning):
-        assert np.all(np.array([-10, -5, 0, 5, 10]) == raster.convert_scale(a, 'db', 'db'))
+        assert np.allclose(raster.convert_scale(a, 'db', 'db'), np.array([-10, -5, 0, 5, 10]))
+
+
+def test_convert_scale_masked_arrays():
+    masked_array = np.ma.MaskedArray([-1, 0, 1, 4, 9], mask=[False, False, False, False, False])
+    c = raster.convert_scale(masked_array, 'power', 'db')
+    assert np.allclose(c.mask, [True, True, False, False, False])
+    assert np.allclose(
+        c, np.ma.MaskedArray([np.nan, -np.inf, 0., 6.02059991, 9.54242509], mask=[True, True, False, False, False])
+    )
+
+    a = raster.convert_scale(c, 'db', 'power')
+    assert np.allclose(a.mask, [True, True, False, False, False])
+    assert np.allclose(a, np.ma.MaskedArray([-1, 0, 1, 4, 9], mask=[True, True, False, False, False]))


### PR DESCRIPTION
`raster.py` hasn't been released yet, so changelog is current still

reordered tests to "what you got compared to what you shoulda got" convention