### PR TITLE
Watermap improvements

### DIFF
--- a/asf_tools/hand/prepare.py
+++ b/asf_tools/hand/prepare.py
@@ -28,7 +28,7 @@ def prepare_hand_vrt(vrt: Union[str, Path], geometry: Union[ogr.Geometry, BaseGe
 
     Args:
         vrt: Path for the output VRT file
-        geometry: Geometry in EPSG:4326 (lon/lat) projection for which to prepare a DEM mosaic
+        geometry: Geometry in EPSG:4326 (lon/lat) projection for which to prepare a HAND mosaic
 
     """
     with GDALConfigManager(GDAL_DISABLE_READDIR_ON_OPEN='EMPTY_DIR'):

--- a/asf_tools/water_map.py
+++ b/asf_tools/water_map.py
@@ -98,7 +98,7 @@ def min_max_membership(array: np.ndarray, lower_limit: float, upper_limit: float
     return membership
 
 
-def segment_area_membership(segments: np.ndarray,min_area: int = 3, max_area: int = 10) -> \
+def segment_area_membership(segments: np.ndarray, min_area: int = 3, max_area: int = 10) -> \
         np.ndarray:
     segment_areas = np.bincount(segments.ravel())
 

--- a/asf_tools/water_map.py
+++ b/asf_tools/water_map.py
@@ -87,7 +87,7 @@ def determine_membership_limits(
     array = np.ma.masked_values(array, 0.)
     array = np.ma.masked_greater(array, np.percentile(array, mask_percentile))
     lower_limit = np.ma.median(array)
-    upper_limit = lower_limit + std_range * array.std()
+    upper_limit = lower_limit + std_range * array.std() + 5.0
     return lower_limit, upper_limit
 
 

--- a/asf_tools/water_map.py
+++ b/asf_tools/water_map.py
@@ -91,14 +91,6 @@ def determine_membership_limits(
     return lower_limit, upper_limit
 
 
-def segment_image(image: np.ndarray) -> np.ndarray:
-    med = filters.median(image, morphology.disk(2))
-    selem = morphology.disk(3)
-    closed = morphology.closing(med, selem)
-    segments = measure.label(closed, connectivity=2)
-    return segments
-
-
 def min_max_membership(array: np.ndarray, lower_limit: float, upper_limit: float, resolution: float) -> np.ndarray:
     possible_values = np.arange(array.min(), array.max(), resolution)
     activation = fuzz.zmf(possible_values, lower_limit, upper_limit)
@@ -122,7 +114,7 @@ def fuzzy_refinement(initial_map: np.ndarray, gaussian_array: np.ndarray, hand_a
                      gaussian_thresholds: Tuple[float, float], membership_threshold: float = 0.45) -> np.ndarray:
     water_map = np.ones_like(initial_map)
 
-    water_segments = segment_image(initial_map)
+    water_segments = measure.label(initial_map, connectivity=2)
     water_segment_membership = segment_area_membership(water_segments, initial_map)
     water_map &= ~np.isclose(water_segment_membership, 0.)
 

--- a/asf_tools/water_map.py
+++ b/asf_tools/water_map.py
@@ -98,7 +98,7 @@ def min_max_membership(array: np.ndarray, lower_limit: float, upper_limit: float
     return membership
 
 
-def segment_area_membership(segments: np.ndarray, initial_mask: np.ndarray, min_area: int = 3, max_area: int = 10) -> \
+def segment_area_membership(segments: np.ndarray,min_area: int = 3, max_area: int = 10) -> \
         np.ndarray:
     segment_areas = np.bincount(segments.ravel())
 
@@ -111,8 +111,7 @@ def segment_area_membership(segments: np.ndarray, initial_mask: np.ndarray, min_
     np.putmask(segment_membership, np.isin(segment_membership, segments_above_threshold), 1)
 
     for area in possible_areas:
-        possible_pixels = np.isin(segments, (segment_areas == area).nonzero())
-        mask = np.logical_and(possible_pixels, initial_mask)
+        mask = np.isin(segments, (segment_areas == area).nonzero())
         np.putmask(segment_membership, mask, fuzz.interp_membership(possible_areas, activation, area))
     return segment_membership
 
@@ -122,7 +121,7 @@ def fuzzy_refinement(initial_map: np.ndarray, gaussian_array: np.ndarray, hand_a
     water_map = np.ones_like(initial_map)
 
     water_segments = measure.label(initial_map, connectivity=2)
-    water_segment_membership = segment_area_membership(water_segments, initial_map)
+    water_segment_membership = segment_area_membership(water_segments)
     water_map &= ~np.isclose(water_segment_membership, 0.)
 
     gaussian_membership = min_max_membership(gaussian_array, gaussian_thresholds[0], gaussian_thresholds[1], 0.005)

--- a/asf_tools/water_map.py
+++ b/asf_tools/water_map.py
@@ -98,8 +98,7 @@ def min_max_membership(array: np.ndarray, lower_limit: float, upper_limit: float
     return membership
 
 
-def segment_area_membership(segments: np.ndarray, min_area: int = 3, max_area: int = 10) -> \
-        np.ndarray:
+def segment_area_membership(segments: np.ndarray, min_area: int = 3, max_area: int = 10) -> np.ndarray:
     segment_areas = np.bincount(segments.ravel())
 
     possible_areas = np.arange(min_area, max_area + 1)

--- a/asf_tools/water_map.py
+++ b/asf_tools/water_map.py
@@ -15,7 +15,7 @@ from typing import Optional, Tuple, Union
 import numpy as np
 import skfuzzy as fuzz
 from osgeo import gdal
-from skimage import filters, measure, morphology
+from skimage import measure
 
 from asf_tools.composite import get_epsg_code, write_cog
 from asf_tools.hand.prepare import prepare_hand_for_raster
@@ -98,15 +98,24 @@ def min_max_membership(array: np.ndarray, lower_limit: float, upper_limit: float
     return membership
 
 
-def segment_area_membership(segments: np.ndarray, weights: np.ndarray) -> np.ndarray:
-    segment_areas = np.bincount(segments.ravel())[1:]
-    largest_segment = np.argmax(np.bincount(segments.flat, weights=weights.flat))
-    possible_segments = np.arange(1, np.sum(segments == largest_segment) + 10)
-    activation = 1 - fuzz.zmf(possible_segments, 3, 10)
+def segment_area_membership(segments: np.ndarray, min_area: int = 3, max_area: int = 10) -> np.ndarray:
+    segment_areas = np.bincount(segments.ravel())
+    segment_index = np.arange(segment_areas.size)
+
+    possible_areas = np.arange(min_area, max_area + 1)
+    activation = 1 - fuzz.zmf(possible_areas, min_area, max_area)
+
     segment_membership = np.zeros_like(segments)
-    for segment in range(1, segments.max()):
+
+    segments_above_threshold = segment_index[segment_areas > max_area]
+    np.putmask(segment_membership, np.isin(segment_membership, segments_above_threshold), 1)
+
+    segments_to_interp = segment_index[
+        np.logical_and(segment_areas >= min_area, segment_areas <= max_area)
+    ]
+    for segment in segments_to_interp:
         np.putmask(segment_membership, segments == segment,
-                   fuzz.interp_membership(possible_segments, activation, segment_areas[segment - 1]))
+                   fuzz.interp_membership(possible_areas, activation, segment_areas[segment]))
     return segment_membership
 
 
@@ -115,7 +124,7 @@ def fuzzy_refinement(initial_map: np.ndarray, gaussian_array: np.ndarray, hand_a
     water_map = np.ones_like(initial_map)
 
     water_segments = measure.label(initial_map, connectivity=2)
-    water_segment_membership = segment_area_membership(water_segments, initial_map)
+    water_segment_membership = segment_area_membership(water_segments)
     water_map &= ~np.isclose(water_segment_membership, 0.)
 
     gaussian_membership = min_max_membership(gaussian_array, gaussian_thresholds[0], gaussian_thresholds[1], 0.005)


### PR DESCRIPTION
A few improvements from Franz intended to:
* Tweak the HAND upper limit calculation to prevent correct water pixels from being removed (due to random noise from vegetation)
* Drop the morphological filter step
* reduce the unnecessary work in the area membership segmentation

---

Previously, we generated a golden map that looks like this (note: overview):
![image](https://user-images.githubusercontent.com/7882693/121234491-38b85a00-c840-11eb-80ac-40918ad4f3b7.png)

Now, we're creating a map like this:
![image](https://user-images.githubusercontent.com/7882693/121234585-55549200-c840-11eb-9a52-ba9814ce6a9a.png)

which picks up a bit more water pixels from the initial map:
![image](https://user-images.githubusercontent.com/7882693/121234541-48d03980-c840-11eb-940c-afdab00e87cb.png)
