### PR TITLE
raise error when hand is flat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.3.1](https://github.com/ASFHyP3/asf-tools/compare/v0.3.0...v0.3.1)
+
+### Changed
+* `asf_tools.water_map` will raise a `ValueError` error if the HAND data is all zero
+
 ## [0.3.0](https://github.com/ASFHyP3/asf-tools/compare/v0.2.0...v0.3.0)
 
 ### Added

--- a/asf_tools/water_map.py
+++ b/asf_tools/water_map.py
@@ -37,9 +37,8 @@ def mean_of_subtiles(tiles: np.ndarray) -> np.ndarray:
 
 def select_hand_tiles(tiles: Union[np.ndarray, np.ma.MaskedArray],
                       hand_threshold: float, hand_fraction: float) -> np.ndarray:
-    valid_data = tiles.data[~tiles.mask] if isinstance(tiles, np.ma.MaskedArray) else tiles.ravel()
-    if np.allclose(valid_data, valid_data[0]):
-        raise ValueError(f'All pixels in scene have a HAND value of {valid_data[0]} (completely flat); '
+    if np.allclose(tiles, 0.0):
+        raise ValueError(f'All pixels in scene have a HAND value of {0.0} (all water); '
                          f'scene is not a good candidate for water mapping.')
 
     tile_indexes = np.arange(tiles.shape[0])

--- a/asf_tools/water_map.py
+++ b/asf_tools/water_map.py
@@ -35,7 +35,13 @@ def mean_of_subtiles(tiles: np.ndarray) -> np.ndarray:
     return sub_tiles_mean
 
 
-def select_hand_tiles(tiles: np.ndarray, hand_threshold: float, hand_fraction: float) -> np.ndarray:
+def select_hand_tiles(tiles: Union[np.ndarray, np.ma.MaskedArray],
+                      hand_threshold: float, hand_fraction: float) -> np.ndarray:
+    valid_data = tiles.data[~tiles.mask] if isinstance(tiles, np.ma.MaskedArray) else tiles.ravel()
+    if np.all(valid_data == valid_data[0]):
+        raise ValueError(f'All pixels in scene have a HAND value of {valid_data[0]} (completely flat); '
+                         f'scene is not a good candidate for water mapping.')
+
     tile_indexes = np.arange(tiles.shape[0])
 
     tiles = np.ma.masked_greater_equal(tiles, hand_threshold)

--- a/asf_tools/water_map.py
+++ b/asf_tools/water_map.py
@@ -38,7 +38,7 @@ def mean_of_subtiles(tiles: np.ndarray) -> np.ndarray:
 def select_hand_tiles(tiles: Union[np.ndarray, np.ma.MaskedArray],
                       hand_threshold: float, hand_fraction: float) -> np.ndarray:
     valid_data = tiles.data[~tiles.mask] if isinstance(tiles, np.ma.MaskedArray) else tiles.ravel()
-    if np.all(valid_data == valid_data[0]):
+    if np.allclose(valid_data, valid_data[0]):
         raise ValueError(f'All pixels in scene have a HAND value of {valid_data[0]} (completely flat); '
                          f'scene is not a good candidate for water mapping.')
 

--- a/tests/test_water_map.py
+++ b/tests/test_water_map.py
@@ -25,9 +25,6 @@ def test_select_hand_tiles(hand_candidates):
     with pytest.raises(ValueError):
         _ = water_map.select_hand_tiles(np.zeros(shape=(10, 10, 10), dtype=float), 15., 0.8)
 
-    with pytest.raises(ValueError):
-        _ = water_map.select_hand_tiles(11.3*np.ones(shape=(10, 10, 10), dtype=float), 15., 0.8)
-
 
 @pytest.mark.integration
 def test_select_backscatter_tiles(hand_candidates):

--- a/tests/test_water_map.py
+++ b/tests/test_water_map.py
@@ -22,6 +22,12 @@ def test_select_hand_tiles(hand_candidates):
     selected_tiles = water_map.select_hand_tiles(hand_tiles, 15., 0.8)
     assert np.all(selected_tiles == hand_candidates)
 
+    with pytest.raises(ValueError):
+        _ = water_map.select_hand_tiles(np.zeros(shape=(10, 10, 10), dtype=float), 15., 0.8)
+
+    with pytest.raises(ValueError):
+        _ = water_map.select_hand_tiles(11.3*np.ones(shape=(10, 10, 10), dtype=float), 15., 0.8)
+
 
 @pytest.mark.integration
 def test_select_backscatter_tiles(hand_candidates):


### PR DESCRIPTION
Currently, if the HAND is completely flat (e.g., ocean scene), water mapping code will fail in fuzzy refinement with a very undescriptive error:
```
Traceback (most recent call last):
  ...
  File ".../asf_tools/water_map.py", line 272, in make_water_map
    water_map = fuzzy_refinement(
  File ".../asf_tools/water_map.py", line 141, in fuzzy_refinement
    hand_membership = min_max_membership(hand_array, hand_lower_limit, hand_upper_limit, 0.1)
  File ".../asf_tools/water_map.py", line 96, in min_max_membership
    activation = fuzz.zmf(possible_values, lower_limit, upper_limit)
  File ".../lib/python3.9/site-packages/skfuzzy/membership/generatemf.py", line 476, in zmf
    assert a <= b, 'a <= b is required.'
AssertionError: a <= b is required.
```

This fails much earlier by checking for a flat hand upfront and raising an error