### PR TITLE
Bugfix: vsi paths to calculate_hand entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 * `asf_tools.hand.calculate_hand` now explicitly uses `Pysheds.prid.Grid` because
   `sGrid` has no `add_gridded_data` attribute
+* `calculate_hand` entrypoint now allows GDAL virtual file system (`/vsi*`) paths
+  for the `hand_raster` and `vector_file` arguments
 
 ## [0.3.2](https://github.com/ASFHyP3/asf-tools/compare/v0.3.1...v0.3.2)
 

--- a/asf_tools/hand/calculate.py
+++ b/asf_tools/hand/calculate.py
@@ -158,11 +158,10 @@ def main():
         epilog='For watershed boundaries, see: https://www.hydrosheds.org/page/hydrobasins',
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument('out_raster', type=Path,
-                        help='HAND GeoTIFF to create')
-    parser.add_argument('vector_file', type=Path,
-                        help='Vector file of watershed boundary (hydrobasin) polygons to calculate HAND over. '
-                             'Vector file Must be openable by GDAL, see: https://gdal.org/drivers/vector/index.html')
+    parser.add_argument('out_raster', help='HAND GeoTIFF to create')
+    parser.add_argument('vector_file', help='Vector file of watershed boundary (hydrobasin) polygons to calculate HAND '
+                                            'over. Vector file Must be openable by GDAL, see: '
+                                            'https://gdal.org/drivers/vector/index.html')
 
     parser.add_argument('-v', '--verbose', action='store_true', help='Turn on verbose logging')
     args = parser.parse_args()


### PR DESCRIPTION
Using the `Path` type for the `hand_raster` and `vector_file` prevents using `/vsicurl` and `/vsis3` because it reduces double `//`s to `/` as seen in this logging output:
```
2022-03-25 10:07:16,736 - INFO - Calculating HAND for /vsicurl/https:/hyp3-testing.s3-us-west-2.amazonaws.com/asf-tools/hand/hybas_af_lev12_v1c_firstpoly.geojson
```
and causes a GDAL/Rasterio/Fiona error when trying to access the path.

`calculate_hand` takes either a `str` or a `Path` so using the default `str` type in argparse fixes the issue. 