### PR TITLE
Use the 2021 COP30 release

### DIFF
--- a/asf_tools/dem.py
+++ b/asf_tools/dem.py
@@ -8,7 +8,7 @@ from shapely.geometry.base import BaseGeometry
 from asf_tools import vector
 from asf_tools.util import GDALConfigManager
 
-DEM_GEOJSON = '/vsicurl/https://asf-dem-west.s3.amazonaws.com/v2/cop30-2021-us-west-2-mirror.geojson'
+DEM_GEOJSON = '/vsicurl/https://asf-dem-west.s3.amazonaws.com/v2/cop30-2021.geojson'
 
 gdal.UseExceptions()
 ogr.UseExceptions()

--- a/asf_tools/dem.py
+++ b/asf_tools/dem.py
@@ -8,7 +8,7 @@ from shapely.geometry.base import BaseGeometry
 from asf_tools import vector
 from asf_tools.util import GDALConfigManager
 
-DEM_GEOJSON = '/vsicurl/https://asf-dem-west.s3.amazonaws.com/v2/cop30.geojson'
+DEM_GEOJSON = '/vsicurl/https://asf-dem-west.s3.amazonaws.com/v2/cop30-2021-us-west-2-mirror.geojson'
 
 gdal.UseExceptions()
 ogr.UseExceptions()

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -40,7 +40,7 @@ def test_get_intersecting_feature_properties():
     }
     geometry = ogr.CreateGeometryFromJson(json.dumps(geojson))
     assert vector.intersecting_feature_properties(geometry, dem_tile_features, 'file_path') == [
-        '/vsicurl/https://asf-dem-west.s3.amazonaws.com/v2/COP30/2021/'
+        '/vsicurl/https://copernicus-dem-30m.s3.amazonaws.com/2021/'
         'Copernicus_DSM_COG_10_S46_00_E169_00_DEM/Copernicus_DSM_COG_10_S46_00_E169_00_DEM.tif'
     ]
 
@@ -50,9 +50,9 @@ def test_get_intersecting_feature_properties():
     }
     geometry = ogr.CreateGeometryFromJson(json.dumps(geojson))
     assert vector.intersecting_feature_properties(geometry, dem_tile_features, 'file_path') == [
-        '/vsicurl/https://asf-dem-west.s3.amazonaws.com/v2/COP30/2021/'
+        '/vsicurl/https://copernicus-dem-30m.s3.amazonaws.com/2021/'
         'Copernicus_DSM_COG_10_N73_00_W122_00_DEM/Copernicus_DSM_COG_10_N73_00_W122_00_DEM.tif',
-        '/vsicurl/https://asf-dem-west.s3.amazonaws.com/v2/COP30/2021/'
+        '/vsicurl/https://copernicus-dem-30m.s3.amazonaws.com/2021/'
         'Copernicus_DSM_COG_10_S46_00_E169_00_DEM/Copernicus_DSM_COG_10_S46_00_E169_00_DEM.tif',
     ]
 

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -40,7 +40,7 @@ def test_get_intersecting_feature_properties():
     }
     geometry = ogr.CreateGeometryFromJson(json.dumps(geojson))
     assert vector.intersecting_feature_properties(geometry, dem_tile_features, 'file_path') == [
-        '/vsicurl/https://copernicus-dem-30m.s3.amazonaws.com/'
+        '/vsicurl/https://asf-dem-west.s3.amazonaws.com/v2/COP30/2021/'
         'Copernicus_DSM_COG_10_S46_00_E169_00_DEM/Copernicus_DSM_COG_10_S46_00_E169_00_DEM.tif'
     ]
 
@@ -50,10 +50,10 @@ def test_get_intersecting_feature_properties():
     }
     geometry = ogr.CreateGeometryFromJson(json.dumps(geojson))
     assert vector.intersecting_feature_properties(geometry, dem_tile_features, 'file_path') == [
-        '/vsicurl/https://copernicus-dem-30m.s3.amazonaws.com/'
-        'Copernicus_DSM_COG_10_S46_00_E169_00_DEM/Copernicus_DSM_COG_10_S46_00_E169_00_DEM.tif',
-        '/vsicurl/https://copernicus-dem-30m.s3.amazonaws.com/'
+        '/vsicurl/https://asf-dem-west.s3.amazonaws.com/v2/COP30/2021/'
         'Copernicus_DSM_COG_10_N73_00_W122_00_DEM/Copernicus_DSM_COG_10_N73_00_W122_00_DEM.tif',
+        '/vsicurl/https://asf-dem-west.s3.amazonaws.com/v2/COP30/2021/'
+        'Copernicus_DSM_COG_10_S46_00_E169_00_DEM/Copernicus_DSM_COG_10_S46_00_E169_00_DEM.tif',
     ]
 
 


### PR DESCRIPTION
This:
1. switches to the 2021 COP30 DEM release
2. switches to the ASF DEM mirror in `us-west-2` instead of `eu-central-1`

For (2), we aren't using `prepare_dem_vrt` except for calculating the HAND (water products are using the DEM GeoTIFF in the RTC products. I'm not sure if we want to (a) always point to the canonical bucket or (b) point to our mirror. Thoughts?
