### PR TITLE
retry batch jobs on failure

### DIFF
--- a/asf_tools/hand/handcloudformation.yml
+++ b/asf_tools/hand/handcloudformation.yml
@@ -4,11 +4,14 @@ Parameters:
 
   bucket:
     Type: String
+
   DockerImage:
     Type: String
     Default: ghcr.io/asfhyp3/asf-tools
+
   DockerTag:
     Type: String
+
   VpcId:
     Type: AWS::EC2::VPC::Id
 
@@ -35,6 +38,8 @@ Resources:
         - FARGATE
       Parameters:
         dem_tile_url: ""
+      RetryStrategy:
+        Attempts: 3
       ContainerProperties:
         Image: !Sub "${DockerImage}:${DockerTag}"
         JobRoleArn: !GetAtt TaskRole.Arn


### PR DESCRIPTION
If we're running 26,000 jobs at least a few will fail with transient errors (e.g. failed network connections). This PR adds a [RetryStrategy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html) to the job definition so that those jobs that failed will be automatically retried twice.