### PR TITLE
Unrestrict NumPy in environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [0.4.6]
 
 ### Changed
+* Temporary `numpy` version pin was removed; see [#160](https://github.com/ASFHyP3/asf-tools/pull/160)```
+## [0.4.6]
+
+### Changed
 * Updated the metadata for the RGB Decomposition tool in the ArcGIS Toolbox to more accurately reflect behavior
 * Minor formatting and content corrections in all ArcGIS Toolbox xml files
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,7 +22,7 @@ dependencies:
   - astropy
   - fiona
   - gdal>=3.3
-  - numpy<1.24.0
+  - numpy
   - pysheds>=0.3
   - rasterio
   - scikit-fuzzy


### PR DESCRIPTION
Numpy 1.24 includes the removal of a lot of outstanding depreciations and was causing pytest to fail with:
```
ERROR tests/test_hand.py - SystemError: initialization of _internal failed without raising an exception
ERROR tests/test_vector.py - SystemError: initialization of _internal failed without raising an exception
ERROR tests/test_water_map.py - SystemError: initialization of _internal failed without raising an exception
```
Traceback for one of the tests:
```
 ___________________ ERROR collecting tests/test_water_map.py ___________________
tests/test_water_map.py:5: in <module>
    from asf_tools import water_map
/usr/share/miniconda/envs/asf-tools/lib/python3.9/site-packages/asf_tools/water_map.py:21: in <module>
    from asf_tools.hand.prepare import prepare_hand_for_raster
/usr/share/miniconda/envs/asf-tools/lib/python3.9/site-packages/asf_tools/hand/__init__.py:1: in <module>
    from asf_tools.hand.calculate import calculate_hand_for_basins, make_copernicus_hand
/usr/share/miniconda/envs/asf-tools/lib/python3.9/site-packages/asf_tools/hand/calculate.py:15: in <module>
    from pysheds.sgrid import sGrid
/usr/share/miniconda/envs/asf-tools/lib/python3.9/site-packages/pysheds/sgrid.py:29: in <module>
    import pysheds.io
/usr/share/miniconda/envs/asf-tools/lib/python3.9/site-packages/pysheds/io.py:9: in <module>
    from pysheds.sview import Raster, ViewFinder, View
/usr/share/miniconda/envs/asf-tools/lib/python3.9/site-packages/pysheds/sview.py:12: in <module>
    import pysheds._sview as _self
/usr/share/miniconda/envs/asf-tools/lib/python3.9/site-packages/pysheds/_sview.py:2: in <module>
    from numba import njit, prange
/usr/share/miniconda/envs/asf-tools/lib/python3.9/site-packages/numba/__init__.py:43: in <module>
    from numba.np.ufunc import (vectorize, guvectorize, threading_layer,
/usr/share/miniconda/envs/asf-tools/lib/python3.9/site-packages/numba/np/ufunc/__init__.py:3: in <module>
    from numba.np.ufunc.decorators import Vectorize, GUVectorize, vectorize, guvectorize
/usr/share/miniconda/envs/asf-tools/lib/python3.9/site-packages/numba/np/ufunc/decorators.py:3: in <module>
    from numba.np.ufunc import _internal
E   SystemError: initialization of _internal failed without raising an exception
```
We should be able to unrestrict this again once numba compatible with numpy 1.24. More info:
* https://github.com/numba/numba/issues/8615