### PR TITLE
provide token to dispatch action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
         uses: benc-uk/workflow-dispatch@v1.2
         with:
           workflow: update_asf_tools_version.yml
+          token: ${{ secrets.TOOLS_BOT_PAK }}
           repo: ASFHyP3/hyp3-docs
           ref: main
           inputs: '{"asf_tools_version": "${{ steps.release_assets.outputs.version_tag }}"}'


### PR DESCRIPTION
Dispatch workflow failed last release:
![image](https://user-images.githubusercontent.com/7882693/211420644-f1e48f95-8494-4781-ae87-e2daa36f3804.png)


because we stopped providing the `token:` argument when we upgraded the version in #150 . Even though it's no longer needed for triggering workflows in the same repo, it is required to trigger workflows in different repos:
https://github.com/benc-uk/workflow-dispatch#repo

This adds the token back.