### PR TITLE
remove setup.py reference and unnecessary error message

### DIFF
--- a/src/asf_tools/__init__.py
+++ b/src/asf_tools/__init__.py
@@ -2,14 +2,7 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
-try:
-    __version__ = version(__name__)
-except PackageNotFoundError:
-    print('package is not installed!\n'
-          'Install in editable/develop mode via (from the top of this repo):\n'
-          '   python -m pip install -e .[develop]\n'
-          'Or, to just get the version number use:\n'
-          '   python setup.py --version')
+__version__ = version(__name__)
 
 __all__ = [
     '__version__',

--- a/src/asf_tools/__init__.py
+++ b/src/asf_tools/__init__.py
@@ -1,6 +1,6 @@
 """Tools developed by ASF for working with SAR data"""
 
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import version
 
 __version__ = version(__name__)
 


### PR DESCRIPTION
Lingering setup.py reference from the change to src format and pyproject.toml. Removed this reference and an unnecessary error message. 
<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/ASFHyP3/asf-tools/compare/main...develop?template=release.md
 
NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->