### PR TITLE
Fix water_map and flood_map zip paths

### DIFF
--- a/src/asf_tools/flood_map.py
+++ b/src/asf_tools/flood_map.py
@@ -312,7 +312,7 @@ def hyp3():
     log.info(f"Flood depth map created successfully: {flood_map_raster}")
 
     if args.bucket:
-        output_zip = make_archive(base_name=product_name, format='zip', base_dir=product_dir)
+        output_zip = make_archive(base_name=product_name, format='zip', base_dir=product_name)
         upload_file_to_s3(Path(output_zip), args.bucket, args.bucket_prefix)
         for product_file in product_dir.iterdir():
             upload_file_to_s3(product_file, args.bucket, args.bucket_prefix)

--- a/src/asf_tools/water_map.py
+++ b/src/asf_tools/water_map.py
@@ -391,7 +391,7 @@ def hyp3():
     log.info(f'Water map created successfully: {water_map_raster}')
 
     if args.bucket:
-        output_zip = make_archive(base_name=product_name, format='zip', base_dir=product_dir)
+        output_zip = make_archive(base_name=product_name, format='zip', base_dir=product_name)
         upload_file_to_s3(Path(output_zip), args.bucket, args.bucket_prefix)
         for product_file in product_dir.iterdir():
             upload_file_to_s3(product_file, args.bucket, args.bucket_prefix)


### PR DESCRIPTION
Currently, the contents of the output zip archive for water map and flood map jobs is structured like:

```
home/
└── conda/
    └── product-name/
```

This fixes the `make_archive` command so that the output zip archive contains a single `product-name/` directory.

Tested locally with the water map `hyp3` entrypoint.