### PR TITLE
return /vsis3 path from aws.get_path_to_s3_file

### DIFF
--- a/src/asf_tools/aws.py
+++ b/src/asf_tools/aws.py
@@ -46,4 +46,4 @@ def get_path_to_s3_file(bucket_name, bucket_prefix, file_type: str):
     for s3_object in result['Contents']:
         key = s3_object['Key']
         if key.endswith(file_type):
-            return f'/vsicurl/https://{bucket_name}.s3.amazonaws.com/{key}'
+            return f'/vsis3/{bucket_name}/{key}'

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,0 +1,104 @@
+import pytest
+from botocore.stub import ANY, Stubber
+
+from asf_tools import aws
+
+
+@pytest.fixture(autouse=True)
+def s3_stubber():
+    with Stubber(aws.S3_CLIENT) as stubber:
+        yield stubber
+        stubber.assert_no_pending_responses()
+
+
+def test_get_tag_set():
+    assert aws.get_tag_set() == {
+        'TagSet': [
+            {
+                'Key': 'file_type',
+                'Value': 'product'
+            }
+        ]
+    }
+
+
+def test_get_content_type():
+    assert aws.get_content_type('foo') == 'application/octet-stream'
+    assert aws.get_content_type('foo.asfd') == 'application/octet-stream'
+    assert aws.get_content_type('foo.txt') == 'text/plain'
+    assert aws.get_content_type('foo.zip') == 'application/zip'
+    assert aws.get_content_type('foo/bar.png') == 'image/png'
+
+
+def test_upload_file_to_s3(tmp_path, s3_stubber):
+    expected_params = {
+        'Body': ANY,
+        'Bucket': 'myBucket',
+        'Key': 'myFile.zip',
+        'ContentType': 'application/zip',
+    }
+    tag_params = {
+        'Bucket': 'myBucket',
+        'Key': 'myFile.zip',
+        'Tagging': {
+            'TagSet': [
+                {'Key': 'file_type', 'Value': 'product'}
+            ]
+        }
+    }
+    s3_stubber.add_response(method='put_object', expected_params=expected_params, service_response={})
+    s3_stubber.add_response(method='put_object_tagging', expected_params=tag_params, service_response={})
+
+    file_to_upload = tmp_path / 'myFile.zip'
+    file_to_upload.touch()
+    aws.upload_file_to_s3(file_to_upload, 'myBucket')
+
+
+def test_upload_file_to_s3_with_prefix(tmp_path, s3_stubber):
+    expected_params = {
+        'Body': ANY,
+        'Bucket': 'myBucket',
+        'Key': 'myPrefix/myFile.txt',
+        'ContentType': 'text/plain',
+    }
+    tag_params = {
+        'Bucket': 'myBucket',
+        'Key': 'myPrefix/myFile.txt',
+        'Tagging': {
+            'TagSet': [
+                {'Key': 'file_type', 'Value': 'product'}
+            ]
+        }
+    }
+    s3_stubber.add_response(method='put_object', expected_params=expected_params, service_response={})
+    s3_stubber.add_response(method='put_object_tagging', expected_params=tag_params, service_response={})
+    file_to_upload = tmp_path / 'myFile.txt'
+    file_to_upload.touch()
+    aws.upload_file_to_s3(file_to_upload, 'myBucket', 'myPrefix')
+
+
+def test_get_path_to_s3_file(s3_stubber):
+    expected_params = {
+        'Bucket': 'myBucket',
+        'Prefix': 'myPrefix',
+    }
+    service_response = {
+        'Contents': [
+            {'Key': 'myPrefix/foo.txt'},
+            {'Key': 'myPrefix/foo.nc'},
+            {'Key': 'myPrefix/foo.txt'},
+            {'Key': 'myPrefix/bar.nc'},
+        ],
+    }
+
+    s3_stubber.add_response(method='list_objects_v2', expected_params=expected_params,
+                            service_response=service_response)
+    assert aws.get_path_to_s3_file('myBucket', 'myPrefix', file_type='.nc') == '/vsis3/myBucket/myPrefix/foo.nc'
+
+    s3_stubber.add_response(method='list_objects_v2', expected_params=expected_params,
+                            service_response=service_response)
+    assert aws.get_path_to_s3_file('myBucket', 'myPrefix', file_type='.txt') == '/vsis3/myBucket/myPrefix/foo.txt'
+
+    s3_stubber.add_response(method='list_objects_v2', expected_params=expected_params,
+                            service_response=service_response)
+    assert aws.get_path_to_s3_file('myBucket', 'myPrefix', file_type='.csv') is None


### PR DESCRIPTION
The previous code to fetch the input RTC image for water_map or the input water map images for flood_depth didn't work in EDC environments where the content bucket isn't public, e.g.:

```
Found VV raster: /vsicurl/https://hyp3-edc-uat-contentbucket-XXXXXXX.s3.amazonaws.com/f9ff8a26-1890-408e-8050-f27d126e64c4/S1A_IW_20221201T133515_DVP_RTC30_G_gpufed_9BF9_VV.tif
RuntimeError: HTTP response code: 403
```

`get_path_to_s3_file()` returned a /vsicurl path, which doesn't immediately work with private buckets, even if the EC2 machine has valid AWS credentials with the correct permissions. Updating the function to return a /vsis3 path resolves the issue.