### PR TITLE
Fix datatype bug in `asf-tools.flood_map` that caused `flood_mask` to be written incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.5.2]
+
+### FIXED
+* Fix datatype bug in `asf-tools.flood_map` that caused `flood_mask` to be written incorrectly.
+
 ## [0.5.1]
 
 ### Changed

--- a/src/asf_tools/flood_map.py
+++ b/src/asf_tools/flood_map.py
@@ -214,13 +214,15 @@ def make_flood_map(out_raster: Union[str, Path],  vv_raster: Union[str, Path],
     flood_depth[flood_depth < 0] = 0
 
     nodata = -1
-    floodmask_nodata = np.iinfo(np.uint8).max
     flood_depth[padding_mask] = nodata
-    flood_mask[padding_mask] = floodmask_nodata
+
+    floodmask_nodata = np.iinfo(np.uint8).max
+    flood_mask_byte = flood_mask.astype(np.uint8)
+    flood_mask_byte[padding_mask] = floodmask_nodata
 
     write_cog(str(out_raster).replace('.tif', f'_{estimator}_WaterDepth.tif'), flood_depth, transform=geotransform,
               epsg_code=epsg, dtype=gdal.GDT_Float64, nodata_value=nodata)
-    write_cog(str(out_raster).replace('.tif', f'_{estimator}_FloodMask.tif'), flood_mask, transform=geotransform,
+    write_cog(str(out_raster).replace('.tif', f'_{estimator}_FloodMask.tif'), flood_mask_byte, transform=geotransform,
               epsg_code=epsg, dtype=gdal.GDT_Byte, nodata_value=floodmask_nodata)
 
     flood_mask[known_water_mask] = False


### PR DESCRIPTION
<!--
If this is a pull request for a new release, please use the release template:
   https://github.com/ASFHyP3/asf-tools/compare/main...develop?template=release.md
 
NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
changes which you'd like reviewed. Do not open a pull request to update a feature or personal
branch -- simply merge with `git`.
-->