### PR TITLE
Use float NaN value to determine whether to calculate threshold or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
 ## [0.5.3]
-### Changed
-* The `flood_map.iterative` method now generates an initial guess using the `nmad` method and then runs with a maximum step size of 3 instead of the default 0.5.
 
 ## Added
 * You can choose whether an `fmi`  or `ts` minimization metric is used for the `flood_map.iterative` method:
   * the `flood_map` console script entrypoint now accepts a `--min-metric` argument
   * the  `floopd_map.make_flood_map` function now accepts a `min_metric` keyword argument
+
+### Changed
+* The `flood_map.iterative` method now generates an initial guess using the `nmad` method and then runs with a maximum step size of 3 instead of the default 0.5.
+* the known water threshold used to determine perennial water when creating flood maps will be calculated by default, or if `NaN`, using `flood_map.get_pw_threshold`
+
 
 ## [0.5.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * The `flood_map.iterative` method now generates an initial guess using the `nmad` method and then runs with a maximum step size of 3 instead of the default 0.5.
 * the known water threshold used to determine perennial water when creating flood maps will be calculated by default, or if `NaN`, using `flood_map.get_pw_threshold`
 
-
 ## [0.5.2]
 
 ### Added


### PR DESCRIPTION
* if either `nan` or `null` (any case) is passed to `--known-water-threshold`, it will be represented as `np.nan`
* uses `np.nan` to decide whether to calculate the perennial water threshold or not
* sets the known water (perennial) threshold to `np.nan` by default, everywhere

Largly this is because HyP3 will always pass a string to the `--known-water-threshold` argument, and the OpenAPI spec for `type: number` [requires strings representing valid floating-point numbers](https://github.com/OAI/OpenAPI-Specification/issues/603) but can be [nullable](https://swagger.io/docs/specification/data-models/data-types/#null)