### PR TITLE
Don't verify PyPI distributions

### DIFF
--- a/.github/workflows/distribute.yml
+++ b/.github/workflows/distribute.yml
@@ -33,22 +33,3 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.TOOLS_PYPI_PAK }}
-
-  verify-distribution:
-    runs-on: ubuntu-latest
-    needs:
-      - call-version-info-workflow
-      - distribute
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: environment.yml
-
-      - name: Ensure asf_tools v${{ needs.call-version-info-workflow.outputs.version }}} is pip installable
-        run: |
-          python -m pip install asf_tools==${{ needs.call-version-info-workflow.outputs.version_tag }}


### PR DESCRIPTION
PyPI uses a CDN so we'd need to add a delay to this job. I've not actually seen a successful push to PyPI not then be pip installable, so I think we can just drop this instead.