### PR TITLE
Change readme link to full URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/)
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.7.2]
+
+### Fixed
+- Changed relative link to the watermasking readme in the repo readme to the full URL, so that the link is valid when readme content is mirrored in hyp3-docs
+
 ## [0.7.1]
 
 ### Added
@@ -18,7 +23,7 @@ and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.7.0]
 
-## Added
+### Added
 * Scripts and entrypoints for generating our global watermasking dataset added to `watermasking`.
 
 ## [0.6.0]

--- a/src/asf_tools/README.md
+++ b/src/asf_tools/README.md
@@ -166,5 +166,5 @@ For details on the algorithm see the `asf_tools.flood_map.make_flood_map` docstr
 
 The `asf_tools.watermasking` sub-package allows you to create a watermasking dataset 
 over an arbitrary ROI using OpenStreetMap and ESA WorldCover data.
-Note, this program requires `osmium-tool`. See the [watermasking subpackage readme]([watermasking/README.md](https://github.com/ASFHyP3/asf-tools/blob/main/src/asf_tools/watermasking/README.md)https://github.com/ASFHyP3/asf-tools/blob/main/src/asf_tools/watermasking/README.md) 
+Note, this program requires `osmium-tool`. See the [watermasking subpackage readme](https://github.com/ASFHyP3/asf-tools/blob/main/src/asf_tools/watermasking/README.md) 
 for more information on setup and usage.

--- a/src/asf_tools/README.md
+++ b/src/asf_tools/README.md
@@ -166,5 +166,5 @@ For details on the algorithm see the `asf_tools.flood_map.make_flood_map` docstr
 
 The `asf_tools.watermasking` sub-package allows you to create a watermasking dataset 
 over an arbitrary ROI using OpenStreetMap and ESA WorldCover data.
-Note, this program requires `osmium-tool`. See [README.md](watermasking/README.md) 
+Note, this program requires `osmium-tool`. See the [watermasking subpackage readme]([watermasking/README.md](https://github.com/ASFHyP3/asf-tools/blob/main/src/asf_tools/watermasking/README.md)https://github.com/ASFHyP3/asf-tools/blob/main/src/asf_tools/watermasking/README.md) 
 for more information on setup and usage.


### PR DESCRIPTION
This PR replaces the relative link with the full URL for the watermasking readme so that the link will also work in hyp3-docs, which references this readme file for the asf_tools information page.