### PR TITLE
Remove Support for Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -8,5 +8,7 @@ on:
 jobs:
   call-bump-version-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.11.0
+    with:
+      python_version: "3.10"
     secrets:
       USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -8,7 +8,5 @@ on:
 jobs:
   call-bump-version-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.11.0
-    with:
-      python_version: "3.10"
     secrets:
       USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -20,6 +20,8 @@ jobs:
 
   call-version-info-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-version-info.yml@v0.11.0
+    with:
+      python_version: "3.10"
 
   call-docker-ghcr-workflow:
     needs: call-version-info-workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0]
+
+### Removed
+- Support for Python 3.8 and 3.9 has been removed.
 
 ## [0.7.2]
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   # - esri  # windows only
   - nodefaults
 dependencies:
-  - python>=3.8, <3.12
+  - python>=3.10, <3.12
   - pip
   # For packaging, and testing
   # - arcpy  # windows only

--- a/prototype/osl-env.yml
+++ b/prototype/osl-env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.10
+  - python>=3.10, <3.12
   - pip
   # For running
   - asf_search>=0.4

--- a/prototype/osl-env.yml
+++ b/prototype/osl-env.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.8
+  - python>=3.10
   - pip
   # For running
   - asf_search>=0.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "asf_tools"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 authors = [
     {name="ASF APD/Tools Team", email="uaf-asf-apd@alaska.edu"},
 ]
@@ -17,8 +17,6 @@ classifiers=[
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers=[
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
     "astropy",


### PR DESCRIPTION
This PR sets the minimum Python version to 3.10.