### PR TITLE
update read_as_masked_array to handle nan nodata values

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -29,4 +29,4 @@ jobs:
     with:
       version_tag: ${{ needs.call-version-info-workflow.outputs.version_tag }}
     secrets:
-      USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
+      USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [PEP 440](https://www.python.org/dev/peps/pep-0440/) 
 and uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4]
+- Support rasters with `nan` nodata values in `read_as_masked_array`
+  
 ## [0.8.3]
 
 ### Changed

--- a/src/asf_tools/raster.py
+++ b/src/asf_tools/raster.py
@@ -64,7 +64,7 @@ def read_as_masked_array(raster: str | Path, band: int = 1) -> np.ma.MaskedArray
     raster_array = raster_band.ReadAsArray()
     
     nodata = raster_band.GetNoDataValue()
-    if nodata is not None and not np.isnan(nodata):
+    if nodata is not None:
         raster_array = np.ma.masked_values(raster_array, nodata)
     raster_array = np.ma.masked_invalid(raster_array)
     

--- a/src/asf_tools/raster.py
+++ b/src/asf_tools/raster.py
@@ -55,9 +55,8 @@ def read_as_masked_array(raster: str | Path, band: int = 1) -> np.ma.MaskedArray
         band: The raster band to read
 
     Returns:
-        masked_raster: The raster pixel data as a numpy MaskedArray
+        raster_array: The raster pixel data as a numpy MaskedArray
     """
-    print(raster)
     log.debug(f'Reading raster values from {raster}')
     ds = gdal.Open(str(raster))
     raster_band = ds.GetRasterBand(band)

--- a/src/asf_tools/raster.py
+++ b/src/asf_tools/raster.py
@@ -55,17 +55,20 @@ def read_as_masked_array(raster: str | Path, band: int = 1) -> np.ma.MaskedArray
         band: The raster band to read
 
     Returns:
-        data: The raster pixel data as a numpy MaskedArray
+        masked_raster: The raster pixel data as a numpy MaskedArray
     """
     log.debug(f'Reading raster values from {raster}')
     ds = gdal.Open(str(raster))
     raster_band = ds.GetRasterBand(band)
-    data = np.ma.masked_invalid(raster_band.ReadAsArray())
+    
     nodata = raster_band.GetNoDataValue()
-    if nodata is not None:
-        return np.ma.masked_values(data, nodata)
+    if nodata and not np.isnan(nodata):
+        masked_raster = np.ma.masked_values(raster_band, nodata)
+    else:
+        masked_raster = np.ma.masked_invalid(raster_band.ReadAsArray())
+    
     del ds  # How to close w/ gdal
-    return data
+    return masked_raster
 
 
 def read_as_array(raster: str, band: int = 1) -> np.ndarray:

--- a/src/asf_tools/raster.py
+++ b/src/asf_tools/raster.py
@@ -57,18 +57,19 @@ def read_as_masked_array(raster: str | Path, band: int = 1) -> np.ma.MaskedArray
     Returns:
         masked_raster: The raster pixel data as a numpy MaskedArray
     """
+    print(raster)
     log.debug(f'Reading raster values from {raster}')
     ds = gdal.Open(str(raster))
     raster_band = ds.GetRasterBand(band)
+    raster_array = raster_band.ReadAsArray()
     
     nodata = raster_band.GetNoDataValue()
-    if nodata and not np.isnan(nodata):
-        masked_raster = np.ma.masked_values(raster_band, nodata)
-    else:
-        masked_raster = np.ma.masked_invalid(raster_band.ReadAsArray())
+    if nodata is not None and not np.isnan(nodata):
+        raster_array = np.ma.masked_values(raster_array, nodata)
+    raster_array = np.ma.masked_invalid(raster_array)
     
     del ds  # How to close w/ gdal
-    return masked_raster
+    return raster_array
 
 
 def read_as_array(raster: str, band: int = 1) -> np.ndarray:


### PR DESCRIPTION
- Fixes #270

Rasters with `nan` nodata values are returned as masked arrays with no masks (data.mask == np.False_). 

This happened because `nan` == `nan` evaluates to False, as does `np.nan` == `None`.

A nodata value of `nan` enters the branch:
```
    if nodata is not None:
        return np.ma.masked_values(data, nodata)
```

Then, `np.ma.masked_values(data, nodata)` masks all values where `np.nan` == `np.nan`, which never evaluates to `True` and therefore results in no mask.

`ds` is now deleted, regardless of branching. 